### PR TITLE
Improve CLI help structure

### DIFF
--- a/internal/cli/authors.go
+++ b/internal/cli/authors.go
@@ -74,7 +74,9 @@ func createAuthor(serverURL, name string) (authors.Author, error) {
 
 func runAuthors(args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "missing authors command")
+		_, _ = fmt.Fprintln(stderr, "Error: missing authors command")
+		_, _ = fmt.Fprintln(stderr)
+		printAuthorsHelp(stderr)
 		return 2
 	}
 
@@ -85,10 +87,27 @@ func runAuthors(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "add":
 		return runAuthorsAdd(args[1:], stdout, stderr)
 
+	case "help", "-h", "--help":
+		printAuthorsHelp(stdout)
+		return 0
+
 	default:
-		_, _ = fmt.Fprintf(stderr, "unknown authors command %q\n", args[0])
+		_, _ = fmt.Fprintf(stderr, "Error: unknown authors command %q\n\n", args[0])
+		printAuthorsHelp(stderr)
 		return 2
 	}
+}
+
+func printAuthorsHelp(w io.Writer) {
+	printCommandHelp(w, commandHelp{
+		name:        "bookist authors",
+		usage:       "bookist authors [command [command options]]",
+		description: "Manage authors",
+		commands: []helpCommand{
+			{name: "list", description: "List authors"},
+			{name: "add", description: "Add an author"},
+		},
+	}, nil)
 }
 
 func runAuthorsList(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -96,10 +115,13 @@ func runAuthorsList(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
 
-	flags.SetOutput(stderr)
-
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist authors list",
+		usage:       "bookist authors list [options]",
+		description: "List authors",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	listed, err := fetchAuthors(*serverURL)
@@ -121,10 +143,13 @@ func runAuthorsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
 	name := flags.String("name", "", "Author name")
 
-	flags.SetOutput(stderr)
-
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist authors add",
+		usage:       "bookist authors add [options]",
+		description: "Add an author",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	author, err := createAuthor(*serverURL, *name)

--- a/internal/cli/books.go
+++ b/internal/cli/books.go
@@ -18,7 +18,9 @@ import (
 
 func runBooks(args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "missing books command")
+		_, _ = fmt.Fprintln(stderr, "Error: missing books command")
+		_, _ = fmt.Fprintln(stderr)
+		printBooksHelp(stderr)
 		return 2
 	}
 
@@ -29,10 +31,27 @@ func runBooks(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "add":
 		return runBooksAdd(args[1:], stdout, stderr)
 
+	case "help", "-h", "--help":
+		printBooksHelp(stdout)
+		return 0
+
 	default:
-		_, _ = fmt.Fprintf(stderr, "unknown books command %q\n", args[0])
+		_, _ = fmt.Fprintf(stderr, "Error: unknown books command %q\n\n", args[0])
+		printBooksHelp(stderr)
 		return 2
 	}
+}
+
+func printBooksHelp(w io.Writer) {
+	printCommandHelp(w, commandHelp{
+		name:        "bookist books",
+		usage:       "bookist books [command [command options]]",
+		description: "Manage books",
+		commands: []helpCommand{
+			{name: "list", description: "List books"},
+			{name: "add", description: "Add a book"},
+		},
+	}, nil)
 }
 
 func runBooksList(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -41,8 +60,13 @@ func runBooksList(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
 
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist books list",
+		usage:       "bookist books list [options]",
+		description: "List books",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	listedBooks, err := fetchBooks(*serverURL)
@@ -122,10 +146,13 @@ func runBooksAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags.Var(&publishedMonth, "published-month", "Publication month (1-12)")
 	flags.Var(&publishedDay, "published-day", "Publication day (1-31)")
 
-	flags.SetOutput(stderr)
-
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist books add",
+		usage:       "bookist books add [options]",
+		description: "Add a book",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	input := books.CreateBookRequest{

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"os"
 )
 
 const (
@@ -22,7 +21,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runServe(args[1:], stdout, stderr)
 
 	case "migrate":
-		return runMigrate(args[1:], stderr)
+		return runMigrate(args[1:], stdout, stderr)
 
 	case "books":
 		return runBooks(args[1:], stdout, stderr)
@@ -33,32 +32,36 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "lists":
 		return runLists(args[1:], stdout, stderr)
 
-	case "help", "-h", "--help":
-		printUsage(stdout)
+	case "help", "h":
+		if len(args) == 1 {
+			printRootHelp(stdout)
+			return 0
+		}
+		return Run(append(args[1:], "--help"), stdout, stderr)
+
+	case "-h", "--help":
+		printRootHelp(stdout)
 		return 0
 
 	default:
-		_, _ = fmt.Fprintf(stderr, "unknown command %q\n\n", args[0])
-		printUsage(stderr)
+		_, _ = fmt.Fprintf(stderr, "Error: unknown command %q\n\n", args[0])
+		printRootHelp(stderr)
 		return 2
 	}
 }
 
-func printUsage(w io.Writer) {
-	program := "bookist"
-
-	if len(os.Args) > 0 {
-		program = os.Args[0]
-	}
-	_, _ = fmt.Fprintf(w, `Usage:
-  %[1]s serve [--addr :8080] [--db bookist.db]
-  %[1]s migrate [--db bookist.db]
-  %[1]s books list [--server http://localhost:8080]
-  %[1]s books add --title TITLE [--isbn ISBN] [--author NAME_OR_ID ...] [--server http://localhost:8080]
-  %[1]s authors list [--server http://localhost:8080]
-  %[1]s authors add --name NAME [--server http://localhost:8080]
-  %[1]s lists list [--server http://localhost:8080]
-  %[1]s lists add --name NAME [--description DESC] [--server http://localhost:8080]
-  %[1]s lists add-book --list NAME_OR_ID --book TITLE_OR_ID [--server http://localhost:8080]
-`, program)
+func printRootHelp(w io.Writer) {
+	printCommandHelp(w, commandHelp{
+		name:        "bookist",
+		usage:       "bookist [command [command options]]",
+		description: "Manage a home library",
+		commands: []helpCommand{
+			{name: "serve", description: "Start the Bookist server"},
+			{name: "migrate", description: "Run database migrations"},
+			{name: "books", description: "Manage books"},
+			{name: "authors", description: "Manage authors"},
+			{name: "lists", description: "Manage book lists"},
+			{name: "help, h", description: "Show help for a command"},
+		},
+	}, nil)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,191 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+
+	"bakku.dev/bookist/internal/cli"
+)
+
+func TestRootHelpShowsOnlyTopLevelCommands(t *testing.T) {
+	for _, args := range [][]string{{"--help"}, {"-h"}, {"help"}, {"h"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			exitCode, stdout, stderr := runCLI(args)
+
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+
+			for _, expected := range []string{
+				"NAME:\n   bookist - Manage a home library",
+				"serve    Start the Bookist server",
+				"migrate  Run database migrations",
+				"books    Manage books",
+				"authors  Manage authors",
+				"lists    Manage book lists",
+			} {
+				if !strings.Contains(stdout, expected) {
+					t.Errorf("expected stdout to contain %q, got:\n%s", expected, stdout)
+				}
+			}
+
+			for _, unexpected := range []string{"bookist books list", "bookist authors add", "--server"} {
+				if strings.Contains(stdout, unexpected) {
+					t.Errorf("expected stdout not to contain %q, got:\n%s", unexpected, stdout)
+				}
+			}
+		})
+	}
+}
+
+func TestParentHelpShowsOnlyImmediateCommands(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		expected   []string
+		unexpected []string
+	}{
+		{
+			name:       "books",
+			args:       []string{"books", "--help"},
+			expected:   []string{"bookist books - Manage books", "list  List books", "add   Add a book"},
+			unexpected: []string{"Manage authors", "add-book", "--title"},
+		},
+		{
+			name:       "authors",
+			args:       []string{"authors", "--help"},
+			expected:   []string{"bookist authors - Manage authors", "list  List authors", "add   Add an author"},
+			unexpected: []string{"Manage books", "add-book", "--name"},
+		},
+		{
+			name:       "lists",
+			args:       []string{"lists", "--help"},
+			expected:   []string{"bookist lists - Manage book lists", "list      List book lists", "add       Add a book list", "add-book  Add a book to a list"},
+			unexpected: []string{"Manage authors", "--description", "--book"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			exitCode, stdout, stderr := runCLI(test.args)
+
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			for _, expected := range test.expected {
+				if !strings.Contains(stdout, expected) {
+					t.Errorf("expected stdout to contain %q, got:\n%s", expected, stdout)
+				}
+			}
+			for _, unexpected := range test.unexpected {
+				if strings.Contains(stdout, unexpected) {
+					t.Errorf("expected stdout not to contain %q, got:\n%s", unexpected, stdout)
+				}
+			}
+		})
+	}
+}
+
+func TestLeafHelpShowsCommandOptionsAndExitsSuccessfully(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{name: "serve", args: []string{"serve", "--help"}, expected: []string{"bookist serve - Start the Bookist server", "--addr string", "--db string"}},
+		{name: "migrate", args: []string{"migrate", "--help"}, expected: []string{"bookist migrate - Run database migrations", "--db string"}},
+		{name: "books list", args: []string{"books", "list", "--help"}, expected: []string{"bookist books list - List books", "--server string"}},
+		{name: "books add", args: []string{"books", "add", "-h"}, expected: []string{"bookist books add - Add a book", "--author string", "--title string"}},
+		{name: "books add long single dash", args: []string{"books", "add", "-help"}, expected: []string{"bookist books add - Add a book", "--author string", "--title string"}},
+		{name: "authors add", args: []string{"authors", "add", "--help"}, expected: []string{"bookist authors add - Add an author", "--name string"}},
+		{name: "lists add-book", args: []string{"lists", "add-book", "--help"}, expected: []string{"bookist lists add-book - Add a book to a list", "--book string", "--list string"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			exitCode, stdout, stderr := runCLI(test.args)
+
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			for _, expected := range test.expected {
+				if !strings.Contains(stdout, expected) {
+					t.Errorf("expected stdout to contain %q, got:\n%s", expected, stdout)
+				}
+			}
+		})
+	}
+}
+
+func TestFlagErrorShowsOnlyCommandHelp(t *testing.T) {
+	exitCode, stdout, stderr := runCLI([]string{"books", "add", "--pages", "many"})
+
+	if exitCode != 2 {
+		t.Fatalf("expected exit code 2, got %d", exitCode)
+	}
+	if stdout != "" {
+		t.Fatalf("expected empty stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, `invalid value "many" for flag -pages`) {
+		t.Errorf("expected invalid flag error, got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "bookist books add - Add a book") {
+		t.Errorf("expected books add help, got:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "Usage of books add:") {
+		t.Errorf("expected Go flag usage to be suppressed, got:\n%s", stderr)
+	}
+}
+
+func TestInvalidSubcommandShowsParentHelp(t *testing.T) {
+	for _, parent := range []string{"books", "authors", "lists"} {
+		t.Run(parent, func(t *testing.T) {
+			exitCode, stdout, stderr := runCLI([]string{parent, "invalid"})
+
+			if exitCode != 2 {
+				t.Fatalf("expected exit code 2, got %d", exitCode)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, "Error: unknown "+parent+" command \"invalid\"") {
+				t.Errorf("expected unknown command error, got:\n%s", stderr)
+			}
+			if !strings.Contains(stderr, "bookist "+parent+" - Manage") {
+				t.Errorf("expected %s help, got:\n%s", parent, stderr)
+			}
+			if strings.Contains(stderr, "Start the Bookist server") {
+				t.Errorf("expected parent help rather than root help, got:\n%s", stderr)
+			}
+		})
+	}
+}
+
+func TestHelpCommandAcceptsACommandPath(t *testing.T) {
+	exitCode, stdout, stderr := runCLI([]string{"help", "books", "add"})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "bookist books add - Add a book") {
+		t.Fatalf("expected books add help, got:\n%s", stdout)
+	}
+}
+
+func runCLI(args []string) (int, string, string) {
+	var stdout, stderr strings.Builder
+	exitCode := cli.Run(args, &stdout, &stderr)
+	return exitCode, stdout.String(), stderr.String()
+}

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -10,14 +10,18 @@ import (
 	"bakku.dev/bookist/internal/database"
 )
 
-func runMigrate(args []string, stderr io.Writer) int {
+func runMigrate(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("migrate", flag.ContinueOnError)
-	flags.SetOutput(stderr)
 
 	dbPath := flags.String("db", defaultDBPath, "SQLite database path")
 
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist migrate",
+		usage:       "bookist migrate [options]",
+		description: "Run database migrations",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	db, err := openAndMigrate(context.Background(), *dbPath)

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+type helpCommand struct {
+	name        string
+	description string
+}
+
+type commandHelp struct {
+	name        string
+	usage       string
+	description string
+	commands    []helpCommand
+}
+
+func printCommandHelp(w io.Writer, help commandHelp, flags *flag.FlagSet) {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(tw, "NAME:\n   %s - %s\n\n", help.name, help.description)
+	_, _ = fmt.Fprintf(tw, "USAGE:\n   %s\n", help.usage)
+
+	if len(help.commands) > 0 {
+		_, _ = fmt.Fprintln(tw, "\nCOMMANDS:")
+		for _, command := range help.commands {
+			_, _ = fmt.Fprintf(tw, "   %s\t%s\n", command.name, command.description)
+		}
+	}
+
+	_, _ = fmt.Fprintln(tw, "\nOPTIONS:")
+	if flags != nil {
+		flags.VisitAll(func(f *flag.Flag) {
+			option := "--" + f.Name + flagPlaceholder(f)
+			description := f.Usage
+			if showDefault(f.DefValue) {
+				description += " (default: " + f.DefValue + ")"
+			}
+			_, _ = fmt.Fprintf(tw, "   %s\t%s\n", option, description)
+		})
+	}
+	_, _ = fmt.Fprintln(tw, "   --help, -h\tShow help")
+	_ = tw.Flush()
+}
+
+func parseFlags(flags *flag.FlagSet, args []string, stdout, stderr io.Writer, help commandHelp) (bool, int) {
+	flags.SetOutput(stderr)
+	flags.Usage = func() {}
+
+	err := flags.Parse(args)
+	if errors.Is(err, flag.ErrHelp) {
+		printCommandHelp(stdout, help, flags)
+		return false, 0
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr)
+		printCommandHelp(stderr, help, flags)
+		return false, 2
+	}
+
+	return true, 0
+}
+
+func flagPlaceholder(f *flag.Flag) string {
+	switch f.Value.(type) {
+	case *optionalStringFlag, *stringSliceFlag:
+		return " string"
+	case *optionalIntFlag:
+		return " int"
+	}
+
+	getter, ok := f.Value.(flag.Getter)
+	if !ok {
+		return " value"
+	}
+
+	switch getter.Get().(type) {
+	case bool:
+		return ""
+	case int:
+		return " int"
+	case string:
+		return " string"
+	default:
+		return " value"
+	}
+}
+
+func showDefault(value string) bool {
+	return value != "" && value != "0" && value != "false"
+}

--- a/internal/cli/lists.go
+++ b/internal/cli/lists.go
@@ -16,7 +16,9 @@ import (
 
 func runLists(args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(args) == 0 {
-		_, _ = fmt.Fprintln(stderr, "missing lists command")
+		_, _ = fmt.Fprintln(stderr, "Error: missing lists command")
+		_, _ = fmt.Fprintln(stderr)
+		printListsHelp(stderr)
 		return 2
 	}
 
@@ -30,21 +32,42 @@ func runLists(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "add-book":
 		return runListsAddBook(args[1:], stdout, stderr)
 
+	case "help", "-h", "--help":
+		printListsHelp(stdout)
+		return 0
+
 	default:
-		_, _ = fmt.Fprintf(stderr, "unknown lists command %q\n", args[0])
+		_, _ = fmt.Fprintf(stderr, "Error: unknown lists command %q\n\n", args[0])
+		printListsHelp(stderr)
 		return 2
 	}
+}
+
+func printListsHelp(w io.Writer) {
+	printCommandHelp(w, commandHelp{
+		name:        "bookist lists",
+		usage:       "bookist lists [command [command options]]",
+		description: "Manage book lists",
+		commands: []helpCommand{
+			{name: "list", description: "List book lists"},
+			{name: "add", description: "Add a book list"},
+			{name: "add-book", description: "Add a book to a list"},
+		},
+	}, nil)
 }
 
 func runListsList(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := flag.NewFlagSet("lists list", flag.ContinueOnError)
 
-	flags.SetOutput(stderr)
-
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
 
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist lists list",
+		usage:       "bookist lists list [options]",
+		description: "List book lists",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	endpoint, err := joinURL(*serverURL, "/api/lists")
@@ -85,14 +108,17 @@ func runListsList(args []string, stdout io.Writer, stderr io.Writer) int {
 func runListsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := flag.NewFlagSet("lists add", flag.ContinueOnError)
 
-	flags.SetOutput(stderr)
-
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
 	name := flags.String("name", "", "List name")
 	description := flags.String("description", "", "List description")
 
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist lists add",
+		usage:       "bookist lists add [options]",
+		description: "Add a book list",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	trimmedName := strings.TrimSpace(*name)
@@ -144,14 +170,17 @@ func runListsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 func runListsAddBook(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := flag.NewFlagSet("lists add-book", flag.ContinueOnError)
 
-	flags.SetOutput(stderr)
-
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
 	listRef := flags.String("list", "", "List name or ID")
 	bookRef := flags.String("book", "", "Book title or ID")
 
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist lists add-book",
+		usage:       "bookist lists add-book [options]",
+		description: "Add a book to a list",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	if strings.TrimSpace(*listRef) == "" {

--- a/internal/cli/web.go
+++ b/internal/cli/web.go
@@ -18,13 +18,17 @@ import (
 
 func runServe(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := flag.NewFlagSet("serve", flag.ContinueOnError)
-	flags.SetOutput(stderr)
 
 	addr := flags.String("addr", defaultAddr, "HTTP address to listen on")
 	dbPath := flags.String("db", defaultDBPath, "SQLite database path")
 
-	if err := flags.Parse(args); err != nil {
-		return 2
+	help := commandHelp{
+		name:        "bookist serve",
+		usage:       "bookist serve [options]",
+		description: "Start the Bookist server",
+	}
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
 	}
 
 	db, err := openAndMigrate(context.Background(), *dbPath)


### PR DESCRIPTION
Replace flattened usage output with Tea-style hierarchical help so each command level presents only its immediate commands and options.

- Add shared help rendering and consistent flag parsing behavior
- Show parent usage for missing and invalid resource commands
- Return successful leaf help without running command operations
- Add coverage for help aliases, scoped output, errors, and exit codes