### PR TITLE
Add configurable CLI list output formats

### DIFF
--- a/internal/cli/authors.go
+++ b/internal/cli/authors.go
@@ -114,6 +114,7 @@ func runAuthorsList(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := flag.NewFlagSet("authors list", flag.ContinueOnError)
 
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
+	formatValue := flags.String("format", string(outputFormatTSV), "Output format (tsv|pretty|json)")
 
 	help := commandHelp{
 		name:        "bookist authors list",
@@ -124,14 +125,26 @@ func runAuthorsList(args []string, stdout io.Writer, stderr io.Writer) int {
 		return exitCode
 	}
 
+	format, err := parseOutputFormat(*formatValue)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 2
+	}
+
 	listed, err := fetchAuthors(*serverURL)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "list authors: %v\n", err)
 		return 1
 	}
 
+	rows := make([][]string, 0, len(listed))
 	for _, author := range listed {
-		_, _ = fmt.Fprintf(stdout, "%s\t%s\n", author.ID, author.Name)
+		rows = append(rows, []string{author.ID, author.Name})
+	}
+
+	if err := writeListOutput(stdout, format, listed, []string{"ID", "NAME"}, rows); err != nil {
+		_, _ = fmt.Fprintf(stderr, "list authors: write output: %v\n", err)
+		return 1
 	}
 
 	return 0

--- a/internal/cli/authors_test.go
+++ b/internal/cli/authors_test.go
@@ -42,10 +42,10 @@ func TestAuthorsAddPrintsIDAndName(t *testing.T) {
 
 // ── Authors List ───────────────────────────────────────────────────────────────
 
-func TestAuthorsListPrintsIDAndName(t *testing.T) {
+func TestAuthorsListTableFormats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/authors" {
-			json.NewEncoder(w).Encode([]authors.Author{
+			_ = json.NewEncoder(w).Encode([]authors.Author{
 				{ID: "id-1", Name: "Author One"},
 				{ID: "id-2", Name: "Author Two"},
 			})
@@ -53,16 +53,56 @@ func TestAuthorsListPrintsIDAndName(t *testing.T) {
 	}))
 	defer server.Close()
 
-	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"authors", "list", "--server", server.URL}, &stdout, &stderr)
+	tests := []struct {
+		name     string
+		format   string
+		expected string
+	}{
+		{name: "default TSV", expected: "id-1\tAuthor One\nid-2\tAuthor Two\n"},
+		{name: "explicit TSV", format: "tsv", expected: "id-1\tAuthor One\nid-2\tAuthor Two\n"},
+		{name: "pretty", format: "pretty", expected: "ID    NAME\nid-1  Author One\nid-2  Author Two\n"},
+	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"authors", "list", "--server", server.URL}
+			if test.format != "" {
+				args = append(args, "--format", test.format)
+			}
+
+			exitCode, stdout, stderr := runCLI(args)
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if stdout != test.expected {
+				t.Fatalf("expected stdout %q, got %q", test.expected, stdout)
+			}
+		})
+	}
+}
+
+func TestAuthorsListJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]authors.Author{{ID: "id-1", Name: "Author One"}})
+	}))
+	defer server.Close()
+
+	exitCode, stdout, stderr := runCLI([]string{"authors", "list", "--server", server.URL, "--format", "json"})
 	if exitCode != 0 {
-		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
+		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr)
 	}
-	if !strings.Contains(stdout.String(), "id-1\tAuthor One") {
-		t.Fatalf("expected stdout to contain 'id-1\\tAuthor One', got %q", stdout.String())
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout.String(), "id-2\tAuthor Two") {
-		t.Fatalf("expected stdout to contain 'id-2\\tAuthor Two', got %q", stdout.String())
+
+	var listed []authors.Author
+	if err := json.Unmarshal([]byte(stdout), &listed); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", stdout, err)
+	}
+	if len(listed) != 1 || listed[0].ID != "id-1" || listed[0].Name != "Author One" {
+		t.Fatalf("expected complete author JSON, got %#v", listed)
 	}
 }

--- a/internal/cli/books.go
+++ b/internal/cli/books.go
@@ -59,6 +59,7 @@ func runBooksList(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags.SetOutput(stderr)
 
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
+	formatValue := flags.String("format", string(outputFormatTSV), "Output format (tsv|pretty|json)")
 
 	help := commandHelp{
 		name:        "bookist books list",
@@ -69,18 +70,30 @@ func runBooksList(args []string, stdout io.Writer, stderr io.Writer) int {
 		return exitCode
 	}
 
+	format, err := parseOutputFormat(*formatValue)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 2
+	}
+
 	listedBooks, err := fetchBooks(*serverURL)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "list books: %v\n", err)
 		return 1
 	}
 
+	rows := make([][]string, 0, len(listedBooks))
 	for _, book := range listedBooks {
 		isbn := ""
 		if book.ISBN != nil {
 			isbn = *book.ISBN
 		}
-		_, _ = fmt.Fprintf(stdout, "%s\t%s\t%s\n", book.ID, book.Title, isbn)
+		rows = append(rows, []string{book.ID, book.Title, isbn})
+	}
+
+	if err := writeListOutput(stdout, format, listedBooks, []string{"ID", "TITLE", "ISBN"}, rows); err != nil {
+		_, _ = fmt.Fprintf(stderr, "list books: write output: %v\n", err)
+		return 1
 	}
 
 	return 0

--- a/internal/cli/books_test.go
+++ b/internal/cli/books_test.go
@@ -14,28 +14,83 @@ import (
 
 // ── Books List ─────────────────────────────────────────────────────────────────
 
-func TestBooksListPrintsBooks(t *testing.T) {
+func TestBooksListTableFormats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode([]books.Book{
+		_ = json.NewEncoder(w).Encode([]books.Book{
 			{ID: "id-1", Title: "Dune", ISBN: new("9780441172719")},
 			{ID: "id-2", Title: "Kindred", ISBN: nil},
 		})
 	}))
 	defer server.Close()
 
-	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"books", "list", "--server", server.URL}, &stdout, &stderr)
+	tests := []struct {
+		name     string
+		format   string
+		expected string
+	}{
+		{name: "default TSV", expected: "id-1\tDune\t9780441172719\nid-2\tKindred\t\n"},
+		{name: "explicit TSV", format: "tsv", expected: "id-1\tDune\t9780441172719\nid-2\tKindred\t\n"},
+		{name: "pretty", format: "pretty", expected: "ID    TITLE    ISBN\nid-1  Dune     9780441172719\nid-2  Kindred\n"},
+	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"books", "list", "--server", server.URL}
+			if test.format != "" {
+				args = append(args, "--format", test.format)
+			}
+
+			exitCode, stdout, stderr := runCLI(args)
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if stdout != test.expected {
+				t.Fatalf("expected stdout %q, got %q", test.expected, stdout)
+			}
+		})
+	}
+}
+
+func TestBooksListJSONPreservesNullableFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]books.Book{
+			{
+				ID:      "id-1",
+				Title:   "Dune",
+				ISBN:    new("9780441172719"),
+				Authors: []authors.Author{{ID: "author-1", Name: "Frank Herbert"}},
+			},
+			{ID: "id-2", Title: "Kindred", ISBN: nil},
+		})
+	}))
+	defer server.Close()
+
+	exitCode, stdout, stderr := runCLI([]string{"books", "list", "--server", server.URL, "--format", "json"})
 	if exitCode != 0 {
-		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
+		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
 
-	output := strings.TrimSpace(stdout.String())
-	if !strings.Contains(output, "id-1\tDune\t9780441172719") {
-		t.Fatalf("expected output to contain book with ISBN, got %q", output)
+	var listed []books.Book
+	if err := json.Unmarshal([]byte(stdout), &listed); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", stdout, err)
 	}
-	if !strings.Contains(output, "id-2\tKindred") {
-		t.Fatalf("expected output to contain book without ISBN, got %q", output)
+	if len(listed) != 2 {
+		t.Fatalf("expected 2 books, got %d", len(listed))
+	}
+	if listed[0].ISBN == nil || *listed[0].ISBN != "9780441172719" {
+		t.Fatalf("expected populated ISBN, got %#v", listed[0].ISBN)
+	}
+	if len(listed[0].Authors) != 1 || listed[0].Authors[0].Name != "Frank Herbert" {
+		t.Fatalf("expected complete book JSON with authors, got %#v", listed[0])
+	}
+	if listed[1].ISBN != nil || listed[1].Publisher != nil {
+		t.Fatalf("expected nullable fields to remain nil, got %#v", listed[1])
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,8 @@
 package cli_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -100,10 +102,12 @@ func TestLeafHelpShowsCommandOptionsAndExitsSuccessfully(t *testing.T) {
 	}{
 		{name: "serve", args: []string{"serve", "--help"}, expected: []string{"bookist serve - Start the Bookist server", "--addr string", "--db string"}},
 		{name: "migrate", args: []string{"migrate", "--help"}, expected: []string{"bookist migrate - Run database migrations", "--db string"}},
-		{name: "books list", args: []string{"books", "list", "--help"}, expected: []string{"bookist books list - List books", "--server string"}},
+		{name: "books list", args: []string{"books", "list", "--help"}, expected: []string{"bookist books list - List books", "--format string", "Output format (tsv|pretty|json) (default: tsv)", "--server string"}},
 		{name: "books add", args: []string{"books", "add", "-h"}, expected: []string{"bookist books add - Add a book", "--author string", "--title string"}},
 		{name: "books add long single dash", args: []string{"books", "add", "-help"}, expected: []string{"bookist books add - Add a book", "--author string", "--title string"}},
+		{name: "authors list", args: []string{"authors", "list", "--help"}, expected: []string{"bookist authors list - List authors", "--format string", "Output format (tsv|pretty|json) (default: tsv)", "--server string"}},
 		{name: "authors add", args: []string{"authors", "add", "--help"}, expected: []string{"bookist authors add - Add an author", "--name string"}},
+		{name: "lists list", args: []string{"lists", "list", "--help"}, expected: []string{"bookist lists list - List book lists", "--format string", "Output format (tsv|pretty|json) (default: tsv)", "--server string"}},
 		{name: "lists add-book", args: []string{"lists", "add-book", "--help"}, expected: []string{"bookist lists add-book - Add a book to a list", "--book string", "--list string"}},
 	}
 
@@ -121,6 +125,33 @@ func TestLeafHelpShowsCommandOptionsAndExitsSuccessfully(t *testing.T) {
 				if !strings.Contains(stdout, expected) {
 					t.Errorf("expected stdout to contain %q, got:\n%s", expected, stdout)
 				}
+			}
+		})
+	}
+}
+
+func TestListCommandsRejectUnsupportedFormat(t *testing.T) {
+	for _, resource := range []string{"books", "authors", "lists"} {
+		t.Run(resource, func(t *testing.T) {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+			}))
+			defer server.Close()
+
+			exitCode, stdout, stderr := runCLI([]string{resource, "list", "--server", server.URL, "--format", "xml"})
+			if exitCode != 2 {
+				t.Fatalf("expected exit code 2, got %d", exitCode)
+			}
+			if stdout != "" {
+				t.Fatalf("expected empty stdout, got %q", stdout)
+			}
+			expected := `Error: unsupported output format "xml": must be one of tsv, pretty, json`
+			if !strings.Contains(stderr, expected) {
+				t.Fatalf("expected stderr to contain %q, got %q", expected, stderr)
+			}
+			if requestCount != 0 {
+				t.Fatalf("expected format validation before HTTP request, got %d requests", requestCount)
 			}
 		})
 	}

--- a/internal/cli/lists.go
+++ b/internal/cli/lists.go
@@ -60,6 +60,7 @@ func runListsList(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := flag.NewFlagSet("lists list", flag.ContinueOnError)
 
 	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
+	formatValue := flags.String("format", string(outputFormatTSV), "Output format (tsv|pretty|json)")
 
 	help := commandHelp{
 		name:        "bookist lists list",
@@ -70,36 +71,26 @@ func runListsList(args []string, stdout io.Writer, stderr io.Writer) int {
 		return exitCode
 	}
 
-	endpoint, err := joinURL(*serverURL, "/api/lists")
+	format, err := parseOutputFormat(*formatValue)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "invalid server URL: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 2
 	}
 
-	client := http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(endpoint)
+	listed, err := fetchLists(*serverURL)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "list lists: %v\n", err)
 		return 1
 	}
 
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		_, _ = fmt.Fprintf(stderr, "list lists: server returned %s\n", resp.Status)
-		return 1
-	}
-
-	var listed []lists.List
-	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
-		_, _ = fmt.Fprintf(stderr, "decode lists: %v\n", err)
-		return 1
-	}
-
+	rows := make([][]string, 0, len(listed))
 	for _, list := range listed {
-		_, _ = fmt.Fprintf(stdout, "%s\t%s\n", list.ID, list.Name)
+		rows = append(rows, []string{list.ID, list.Name})
+	}
+
+	if err := writeListOutput(stdout, format, listed, []string{"ID", "NAME"}, rows); err != nil {
+		_, _ = fmt.Fprintf(stderr, "list lists: write output: %v\n", err)
+		return 1
 	}
 
 	return 0

--- a/internal/cli/lists_test.go
+++ b/internal/cli/lists_test.go
@@ -13,10 +13,10 @@ import (
 
 // ── Lists List ────────────────────────────────────────────────────────────────
 
-func TestListsListPrintsIDAndName(t *testing.T) {
+func TestListsListTableFormats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/lists" {
-			json.NewEncoder(w).Encode([]lists.List{
+			_ = json.NewEncoder(w).Encode([]lists.List{
 				{ID: "id-1", Name: "Want to Buy"},
 				{ID: "id-2", Name: "Nightstand"},
 			})
@@ -24,17 +24,67 @@ func TestListsListPrintsIDAndName(t *testing.T) {
 	}))
 	defer server.Close()
 
-	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"lists", "list", "--server", server.URL}, &stdout, &stderr)
+	tests := []struct {
+		name     string
+		format   string
+		expected string
+	}{
+		{name: "default TSV", expected: "id-1\tWant to Buy\nid-2\tNightstand\n"},
+		{name: "explicit TSV", format: "tsv", expected: "id-1\tWant to Buy\nid-2\tNightstand\n"},
+		{name: "pretty", format: "pretty", expected: "ID    NAME\nid-1  Want to Buy\nid-2  Nightstand\n"},
+	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"lists", "list", "--server", server.URL}
+			if test.format != "" {
+				args = append(args, "--format", test.format)
+			}
+
+			exitCode, stdout, stderr := runCLI(args)
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr)
+			}
+			if stderr != "" {
+				t.Fatalf("expected empty stderr, got %q", stderr)
+			}
+			if stdout != test.expected {
+				t.Fatalf("expected stdout %q, got %q", test.expected, stdout)
+			}
+		})
+	}
+}
+
+func TestListsListJSONPreservesNullableDescription(t *testing.T) {
+	description := "Books to purchase"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]lists.List{
+			{ID: "id-1", Name: "Want to Buy", Description: &description},
+			{ID: "id-2", Name: "Nightstand", Description: nil},
+		})
+	}))
+	defer server.Close()
+
+	exitCode, stdout, stderr := runCLI([]string{"lists", "list", "--server", server.URL, "--format", "json"})
 	if exitCode != 0 {
-		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
+		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr)
 	}
-	if !strings.Contains(stdout.String(), "id-1\tWant to Buy") {
-		t.Fatalf("expected stdout to contain 'id-1\\tWant to Buy', got %q", stdout.String())
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
 	}
-	if !strings.Contains(stdout.String(), "id-2\tNightstand") {
-		t.Fatalf("expected stdout to contain 'id-2\\tNightstand', got %q", stdout.String())
+
+	var listed []lists.List
+	if err := json.Unmarshal([]byte(stdout), &listed); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", stdout, err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("expected 2 lists, got %d", len(listed))
+	}
+	if listed[0].Description == nil || *listed[0].Description != description {
+		t.Fatalf("expected populated description, got %#v", listed[0].Description)
+	}
+	if listed[1].Description != nil {
+		t.Fatalf("expected null description, got %#v", listed[1].Description)
 	}
 }
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+type outputFormat string
+
+const (
+	outputFormatTSV    outputFormat = "tsv"
+	outputFormatPretty outputFormat = "pretty"
+	outputFormatJSON   outputFormat = "json"
+)
+
+func parseOutputFormat(value string) (outputFormat, error) {
+	format := outputFormat(value)
+	switch format {
+	case outputFormatTSV, outputFormatPretty, outputFormatJSON:
+		return format, nil
+	default:
+		return "", fmt.Errorf("unsupported output format %q: must be one of tsv, pretty, json", value)
+	}
+}
+
+func writeListOutput(w io.Writer, format outputFormat, value any, headers []string, rows [][]string) error {
+	switch format {
+	case outputFormatTSV:
+		return writeRows(w, rows)
+	case outputFormatPretty:
+		var formatted bytes.Buffer
+		tw := tabwriter.NewWriter(&formatted, 0, 4, 2, ' ', 0)
+		if err := writeRows(tw, append([][]string{headers}, rows...)); err != nil {
+			return err
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+
+		lines := strings.Split(formatted.String(), "\n")
+		for i := range lines {
+			lines[i] = strings.TrimRight(lines[i], " ")
+		}
+		_, err := io.WriteString(w, strings.Join(lines, "\n"))
+		return err
+	case outputFormatJSON:
+		return json.NewEncoder(w).Encode(value)
+	default:
+		return fmt.Errorf("unsupported output format %q", format)
+	}
+}
+
+func writeRows(w io.Writer, rows [][]string) error {
+	for _, row := range rows {
+		if _, err := fmt.Fprintln(w, strings.Join(row, "\t")); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Support automation and interactive use across books, authors, and lists while preserving headerless TSV as the default.

- Add aligned pretty output and full-model JSON output
- Reject unsupported formats before contacting the server
- Cover formats, nullable JSON fields, help text, and error streams

Resolves #2 