### PR TITLE
Add reads with API endpoints and CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Bookist is intended to be a Go application for managing a home library.
 - For list/read behavior, seed SQLite directly and then verify the unit under test reads it correctly.
 - HTTP endpoint tests should not depend on another endpoint, the service, or the repository for setup/assertions. Seed and assert database state directly with test helpers.
 - Keep endpoint tests focused on one route/behavior at a time; avoid combined create-then-list endpoint tests.
+- Group related tests with labeled section markers such as `// ── Reads List ────────────────────────────────────────────────────────────────`.
 
 ## Operational Notes
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,6 +32,9 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "lists":
 		return runLists(args[1:], stdout, stderr)
 
+	case "reads":
+		return runReads(args[1:], stdout, stderr)
+
 	case "help", "h":
 		if len(args) == 1 {
 			printRootHelp(stdout)
@@ -61,6 +64,7 @@ func printRootHelp(w io.Writer) {
 			{name: "books", description: "Manage books"},
 			{name: "authors", description: "Manage authors"},
 			{name: "lists", description: "Manage book lists"},
+			{name: "reads", description: "Manage book reads"},
 			{name: "help, h", description: "Show help for a command"},
 		},
 	}, nil)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,8 @@ import (
 	"bakku.dev/bookist/internal/cli"
 )
 
+// ── Help Display ──────────────────────────────────────────────────────────────
+
 func TestRootHelpShowsOnlyTopLevelCommands(t *testing.T) {
 	for _, args := range [][]string{{"--help"}, {"-h"}, {"help"}, {"h"}} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
@@ -28,6 +30,7 @@ func TestRootHelpShowsOnlyTopLevelCommands(t *testing.T) {
 				"books    Manage books",
 				"authors  Manage authors",
 				"lists    Manage book lists",
+				"reads    Manage book reads",
 			} {
 				if !strings.Contains(stdout, expected) {
 					t.Errorf("expected stdout to contain %q, got:\n%s", expected, stdout)
@@ -67,6 +70,12 @@ func TestParentHelpShowsOnlyImmediateCommands(t *testing.T) {
 			args:       []string{"lists", "--help"},
 			expected:   []string{"bookist lists - Manage book lists", "list      List book lists", "add       Add a book list", "add-book  Add a book to a list"},
 			unexpected: []string{"Manage authors", "--description", "--book"},
+		},
+		{
+			name:       "reads",
+			args:       []string{"reads", "--help"},
+			expected:   []string{"bookist reads - Manage book reads", "list  List reads for a book", "add   Record a read for a book"},
+			unexpected: []string{"Manage authors", "--rating", "--book"},
 		},
 	}
 
@@ -109,6 +118,8 @@ func TestLeafHelpShowsCommandOptionsAndExitsSuccessfully(t *testing.T) {
 		{name: "authors add", args: []string{"authors", "add", "--help"}, expected: []string{"bookist authors add - Add an author", "--name string"}},
 		{name: "lists list", args: []string{"lists", "list", "--help"}, expected: []string{"bookist lists list - List book lists", "--format string", "Output format (tsv|pretty|json) (default: tsv)", "--server string"}},
 		{name: "lists add-book", args: []string{"lists", "add-book", "--help"}, expected: []string{"bookist lists add-book - Add a book to a list", "--book string", "--list string"}},
+		{name: "reads list", args: []string{"reads", "list", "--help"}, expected: []string{"bookist reads list - List reads for a book", "--book string", "--format string"}},
+		{name: "reads add", args: []string{"reads", "add", "--help"}, expected: []string{"bookist reads add - Record a read for a book", "--book string", "--rating float"}},
 	}
 
 	for _, test := range tests {
@@ -130,8 +141,10 @@ func TestLeafHelpShowsCommandOptionsAndExitsSuccessfully(t *testing.T) {
 	}
 }
 
+// ── List Format Validation ────────────────────────────────────────────────────
+
 func TestListCommandsRejectUnsupportedFormat(t *testing.T) {
-	for _, resource := range []string{"books", "authors", "lists"} {
+	for _, resource := range []string{"books", "authors", "lists", "reads"} {
 		t.Run(resource, func(t *testing.T) {
 			requestCount := 0
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -157,6 +170,8 @@ func TestListCommandsRejectUnsupportedFormat(t *testing.T) {
 	}
 }
 
+// ── Error Help ────────────────────────────────────────────────────────────────
+
 func TestFlagErrorShowsOnlyCommandHelp(t *testing.T) {
 	exitCode, stdout, stderr := runCLI([]string{"books", "add", "--pages", "many"})
 
@@ -178,7 +193,7 @@ func TestFlagErrorShowsOnlyCommandHelp(t *testing.T) {
 }
 
 func TestInvalidSubcommandShowsParentHelp(t *testing.T) {
-	for _, parent := range []string{"books", "authors", "lists"} {
+	for _, parent := range []string{"books", "authors", "lists", "reads"} {
 		t.Run(parent, func(t *testing.T) {
 			exitCode, stdout, stderr := runCLI([]string{parent, "invalid"})
 
@@ -200,6 +215,8 @@ func TestInvalidSubcommandShowsParentHelp(t *testing.T) {
 		})
 	}
 }
+
+// ── Help Command ──────────────────────────────────────────────────────────────
 
 func TestHelpCommandAcceptsACommandPath(t *testing.T) {
 	exitCode, stdout, stderr := runCLI([]string{"help", "books", "add"})

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -36,6 +36,26 @@ type optionalIntFlag struct {
 	value *int
 }
 
+type optionalFloatFlag struct {
+	value *float64
+}
+
+func (f *optionalFloatFlag) String() string {
+	if f.value == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*f.value, 'f', -1, 64)
+}
+
+func (f *optionalFloatFlag) Set(value string) error {
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return err
+	}
+	f.value = &parsed
+	return nil
+}
+
 func (f *optionalIntFlag) String() string {
 	if f.value == nil {
 		return ""

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -71,6 +71,8 @@ func flagPlaceholder(f *flag.Flag) string {
 		return " string"
 	case *optionalIntFlag:
 		return " int"
+	case *optionalFloatFlag:
+		return " float"
 	}
 
 	getter, ok := f.Value.(flag.Getter)

--- a/internal/cli/reads.go
+++ b/internal/cli/reads.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"bakku.dev/bookist/internal/reads"
+)
+
+func runReads(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		_, _ = fmt.Fprintln(stderr, "Error: missing reads command")
+		_, _ = fmt.Fprintln(stderr)
+		printReadsHelp(stderr)
+		return 2
+	}
+
+	switch args[0] {
+	case "list":
+		return runReadsList(args[1:], stdout, stderr)
+	case "add":
+		return runReadsAdd(args[1:], stdout, stderr)
+	case "help", "-h", "--help":
+		printReadsHelp(stdout)
+		return 0
+	default:
+		_, _ = fmt.Fprintf(stderr, "Error: unknown reads command %q\n\n", args[0])
+		printReadsHelp(stderr)
+		return 2
+	}
+}
+
+func printReadsHelp(w io.Writer) {
+	printCommandHelp(w, commandHelp{
+		name:        "bookist reads",
+		usage:       "bookist reads [command [command options]]",
+		description: "Manage book reads",
+		commands: []helpCommand{
+			{name: "list", description: "List reads for a book"},
+			{name: "add", description: "Record a read for a book"},
+		},
+	}, nil)
+}
+
+func runReadsList(args []string, stdout io.Writer, stderr io.Writer) int {
+	flags := flag.NewFlagSet("reads list", flag.ContinueOnError)
+
+	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
+	bookRef := flags.String("book", "", "Book title or ID")
+	formatValue := flags.String("format", string(outputFormatTSV), "Output format (tsv|pretty|json)")
+
+	help := commandHelp{
+		name:        "bookist reads list",
+		usage:       "bookist reads list [options]",
+		description: "List reads for a book",
+	}
+
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
+	}
+
+	format, err := parseOutputFormat(*formatValue)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 2
+	}
+
+	if strings.TrimSpace(*bookRef) == "" {
+		_, _ = fmt.Fprintln(stderr, "--book is required")
+		return 2
+	}
+
+	bookID, err := resolveBookID(*serverURL, *bookRef)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	listed, err := fetchReads(*serverURL, bookID)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "list reads: %v\n", err)
+		return 1
+	}
+
+	rows := make([][]string, 0, len(listed))
+
+	for _, read := range listed {
+		rows = append(rows, []string{
+			read.ID,
+			stringValue(read.StartedAt),
+			stringValue(read.FinishedAt),
+			floatValue(read.Rating),
+			stringValue(read.Notes),
+		})
+	}
+
+	if err := writeListOutput(stdout, format, listed,
+		[]string{"ID", "STARTED_AT", "FINISHED_AT", "RATING", "NOTES"}, rows); err != nil {
+		_, _ = fmt.Fprintf(stderr, "list reads: write output: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func runReadsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
+	flags := flag.NewFlagSet("reads add", flag.ContinueOnError)
+
+	serverURL := flags.String("server", defaultServerURL, "Bookist server URL")
+	bookRef := flags.String("book", "", "Book title or ID")
+
+	var startedAt optionalStringFlag
+	var finishedAt optionalStringFlag
+	var rating optionalFloatFlag
+	var notes optionalStringFlag
+
+	flags.Var(&startedAt, "started-at", "Date reading started (YYYY-MM-DD)")
+	flags.Var(&finishedAt, "finished-at", "Date reading finished (YYYY-MM-DD)")
+	flags.Var(&rating, "rating", "Rating from 1 to 5 in increments of 0.5")
+	flags.Var(&notes, "notes", "Read notes")
+
+	help := commandHelp{
+		name:        "bookist reads add",
+		usage:       "bookist reads add [options]",
+		description: "Record a read for a book",
+	}
+
+	if ok, exitCode := parseFlags(flags, args, stdout, stderr, help); !ok {
+		return exitCode
+	}
+
+	if strings.TrimSpace(*bookRef) == "" {
+		_, _ = fmt.Fprintln(stderr, "--book is required")
+		return 2
+	}
+
+	bookID, err := resolveBookID(*serverURL, *bookRef)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	input := reads.CreateReadRequest{
+		StartedAt:  startedAt.value,
+		FinishedAt: finishedAt.value,
+		Rating:     rating.value,
+		Notes:      notes.value,
+	}
+
+	body, err := json.Marshal(input)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "encode read: %v\n", err)
+		return 1
+	}
+
+	endpoint, err := joinURL(*serverURL, "/api/books/"+bookID+"/reads")
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "invalid server URL: %v\n", err)
+		return 2
+	}
+
+	client := http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Post(endpoint, "application/json", bytes.NewReader(body))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "add read: %v\n", err)
+		return 1
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusCreated {
+		_, _ = fmt.Fprintf(stderr, "add read: server returned %s\n", resp.Status)
+		return 1
+	}
+
+	var created reads.Read
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		_, _ = fmt.Fprintf(stderr, "decode read: %v\n", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintf(stdout, "%s\t%s\n", created.ID, created.BookID)
+
+	return 0
+}
+
+func fetchReads(serverURL, bookID string) ([]reads.ListItem, error) {
+	endpoint, err := joinURL(serverURL, "/api/books/"+bookID+"/reads")
+	if err != nil {
+		return nil, fmt.Errorf("invalid server URL: %v", err)
+	}
+
+	client := http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("fetch reads: %v", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch reads: server returned %s", resp.Status)
+	}
+
+	var listed []reads.ListItem
+	if err := json.NewDecoder(resp.Body).Decode(&listed); err != nil {
+		return nil, fmt.Errorf("decode reads: %v", err)
+	}
+
+	return listed, nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func floatValue(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*value, 'f', -1, 64)
+}

--- a/internal/cli/reads_test.go
+++ b/internal/cli/reads_test.go
@@ -1,0 +1,129 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"bakku.dev/bookist/internal/books"
+	"bakku.dev/bookist/internal/reads"
+)
+
+// ── Reads List ────────────────────────────────────────────────────────────────
+
+func TestReadsListResolvesBookAndPrintsTableFormats(t *testing.T) {
+	startedAt := "2026-01-01"
+	finishedAt := "2026-01-03"
+	rating := 4.5
+	notes := "Excellent"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/books":
+			_ = json.NewEncoder(w).Encode([]books.Book{{ID: "book-1", Title: "Dune"}})
+		case "/api/books/book-1/reads":
+			_ = json.NewEncoder(w).Encode([]reads.Read{{
+				ID: "read-1", BookID: "book-1", StartedAt: &startedAt,
+				FinishedAt: &finishedAt, Rating: &rating, Notes: &notes,
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	defer server.Close()
+
+	tests := []struct {
+		name     string
+		format   string
+		expected string
+	}{
+		{name: "default TSV", expected: "read-1\t2026-01-01\t2026-01-03\t4.5\tExcellent\n"},
+		{name: "pretty", format: "pretty", expected: "ID      STARTED_AT  FINISHED_AT  RATING  NOTES\nread-1  2026-01-01  2026-01-03   4.5     Excellent\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := []string{"reads", "list", "--book", "Dune", "--server", server.URL}
+			if test.format != "" {
+				args = append(args, "--format", test.format)
+			}
+			exitCode, stdout, stderr := runCLI(args)
+			if exitCode != 0 || stderr != "" || stdout != test.expected {
+				t.Fatalf("unexpected result: exit=%d stdout=%q stderr=%q", exitCode, stdout, stderr)
+			}
+		})
+	}
+}
+
+func TestReadsListJSONPreservesNullsAndOmitsTimestamps(t *testing.T) {
+	const bookID = "550e8400-e29b-41d4-a716-446655440000"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]reads.Read{{ID: "read-1", BookID: bookID}})
+	}))
+
+	defer server.Close()
+
+	exitCode, stdout, stderr := runCLI([]string{"reads", "list", "--book", bookID, "--server", server.URL, "--format", "json"})
+
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("unexpected result: exit=%d stderr=%q", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, `"started_at":null`) || strings.Contains(stdout, "book_id") || strings.Contains(stdout, "created_at") || strings.Contains(stdout, "updated_at") {
+		t.Fatalf("unexpected JSON output: %s", stdout)
+	}
+}
+
+// ── Reads Add ─────────────────────────────────────────────────────────────────
+
+func TestReadsAddPostsToBookEndpoint(t *testing.T) {
+	const bookID = "550e8400-e29b-41d4-a716-446655440000"
+	var captured reads.CreateReadRequest
+	var capturedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Error(err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(reads.Read{ID: "read-1", BookID: bookID})
+	}))
+
+	defer server.Close()
+
+	exitCode, stdout, stderr := runCLI([]string{
+		"reads", "add", "--book", bookID, "--started-at", "2026-01-01",
+		"--finished-at", "2026-01-03", "--rating", "4.5", "--notes", "Excellent",
+		"--server", server.URL,
+	})
+
+	if exitCode != 0 || stderr != "" {
+		t.Fatalf("unexpected result: exit=%d stderr=%q", exitCode, stderr)
+	}
+	if capturedPath != "/api/books/"+bookID+"/reads" {
+		t.Fatalf("unexpected path %q", capturedPath)
+	}
+	if captured.StartedAt == nil || *captured.StartedAt != "2026-01-01" || captured.Rating == nil || *captured.Rating != 4.5 {
+		t.Fatalf("unexpected request: %#v", captured)
+	}
+	if stdout != "read-1\t"+bookID+"\n" {
+		t.Fatalf("unexpected stdout %q", stdout)
+	}
+}
+
+// ── Reads Book Requirement ────────────────────────────────────────────────────
+
+func TestReadsCommandsRequireBook(t *testing.T) {
+	for _, command := range []string{"list", "add"} {
+		t.Run(command, func(t *testing.T) {
+			exitCode, stdout, stderr := runCLI([]string{"reads", command})
+			if exitCode != 2 || stdout != "" || !strings.Contains(stderr, "--book is required") {
+				t.Fatalf("unexpected result: exit=%d stdout=%q stderr=%q", exitCode, stdout, stderr)
+			}
+		})
+	}
+}

--- a/internal/cli/web.go
+++ b/internal/cli/web.go
@@ -14,6 +14,7 @@ import (
 	"bakku.dev/bookist/internal/books"
 	"bakku.dev/bookist/internal/httpserver"
 	"bakku.dev/bookist/internal/lists"
+	"bakku.dev/bookist/internal/reads"
 )
 
 func runServe(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -50,7 +51,10 @@ func runServe(args []string, stdout io.Writer, stderr io.Writer) int {
 	bookRepo := books.NewSQLiteRepository(db)
 	bookService := books.NewService(bookRepo, authorRepo)
 
-	server, err := httpserver.New(bookService, authorService, listService)
+	readRepo := reads.NewSQLiteRepository(db)
+	readService := reads.NewService(readRepo)
+
+	server, err := httpserver.New(bookService, authorService, listService, readService)
 
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "create server: %v\n", err)

--- a/internal/cli/web_test.go
+++ b/internal/cli/web_test.go
@@ -8,6 +8,8 @@ import (
 	"bakku.dev/bookist/internal/cli"
 )
 
+// ── Serve ─────────────────────────────────────────────────────────────────────
+
 func TestServeWritesListeningStatusToStdout(t *testing.T) {
 	addr := "127.0.0.1:not-a-port"
 	dbPath := filepath.Join(t.TempDir(), "bookist.db")

--- a/internal/database/migrations/00001_initial_tables.sql
+++ b/internal/database/migrations/00001_initial_tables.sql
@@ -39,8 +39,24 @@ CREATE TABLE book_lists (
     book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
     PRIMARY KEY (list_id, book_id)
 );
+CREATE TABLE reads (
+    id TEXT PRIMARY KEY,
+    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    started_at TEXT NULL,
+    finished_at TEXT NULL,
+    rating REAL NULL CHECK (
+        rating IS NULL OR
+        (rating >= 1 AND rating <= 5 AND rating * 2 = CAST(rating * 2 AS INTEGER))
+    ),
+    notes TEXT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK (started_at IS NULL OR finished_at IS NULL OR finished_at >= started_at)
+);
+CREATE INDEX reads_book_id_idx ON reads(book_id);
 
 -- +goose Down
+DROP TABLE reads;
 DROP TABLE book_lists;
 DROP TABLE lists;
 DROP TABLE book_authors;

--- a/internal/httpserver/reads.go
+++ b/internal/httpserver/reads.go
@@ -1,0 +1,71 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"bakku.dev/bookist/internal/reads"
+)
+
+func (s *Server) handleAPIListReads(w http.ResponseWriter, r *http.Request) {
+	result, err := s.reads.ListByBookID(r.Context(), r.PathValue("id"))
+	if err != nil {
+		if errors.Is(err, reads.ErrBookNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
+		http.Error(w, "failed to list reads", http.StatusInternalServerError)
+		return
+	}
+
+	items := make([]reads.ListItem, len(result))
+	for i, read := range result {
+		items[i] = reads.ListItem{
+			ID:         read.ID,
+			StartedAt:  read.StartedAt,
+			FinishedAt: read.FinishedAt,
+			Rating:     read.Rating,
+			Notes:      read.Notes,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, items)
+}
+
+func (s *Server) handleAPICreateRead(w http.ResponseWriter, r *http.Request) {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	var input reads.CreateReadRequest
+	if err := decoder.Decode(&input); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	result, err := s.reads.Create(r.Context(), r.PathValue("id"), input)
+	if err != nil {
+		writeCreateReadError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
+}
+
+func writeCreateReadError(w http.ResponseWriter, err error) {
+	if errors.Is(err, reads.ErrBookNotFound) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if errors.Is(err, reads.ErrInvalidStartedAt) ||
+		errors.Is(err, reads.ErrInvalidFinishedAt) ||
+		errors.Is(err, reads.ErrFinishedBeforeStarted) ||
+		errors.Is(err, reads.ErrInvalidRating) {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	http.Error(w, "failed to create read", http.StatusInternalServerError)
+}

--- a/internal/httpserver/reads_test.go
+++ b/internal/httpserver/reads_test.go
@@ -1,0 +1,186 @@
+package httpserver_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"bakku.dev/bookist/internal/testsupport"
+	"github.com/google/uuid"
+)
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestReadAPICreate(t *testing.T) {
+	app := newTestApp(t)
+
+	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
+	body := bytes.NewBufferString(`{
+		"started_at":"2026-01-01",
+		"finished_at":"2026-01-03",
+		"rating":4.5,
+		"notes":"Excellent"
+	}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/books/"+bookID+"/reads", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	app.handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, resp.Code, resp.Body.String())
+	}
+
+	var response map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["book_id"] != bookID || response["rating"] != 4.5 || response["notes"] != "Excellent" {
+		t.Fatalf("unexpected response: %#v", response)
+	}
+	if _, exists := response["created_at"]; exists {
+		t.Fatal("created_at must not be exposed")
+	}
+	if _, exists := response["updated_at"]; exists {
+		t.Fatal("updated_at must not be exposed")
+	}
+
+	var startedAt, finishedAt, notes sql.NullString
+	var rating sql.NullFloat64
+	var createdAt, updatedAt string
+
+	err := app.db.QueryRowContext(context.Background(), `
+		SELECT started_at, finished_at, rating, notes, created_at, updated_at
+		FROM reads WHERE id = ?
+	`, response["id"]).Scan(&startedAt, &finishedAt, &rating, &notes, &createdAt, &updatedAt)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if startedAt.String != "2026-01-01" || finishedAt.String != "2026-01-03" || rating.Float64 != 4.5 || notes.String != "Excellent" {
+		t.Fatal("unexpected persisted values")
+	}
+	if createdAt == "" || updatedAt == "" {
+		t.Fatal("expected backend-generated timestamps")
+	}
+}
+
+func TestReadAPICreateRejectsClientTimestamp(t *testing.T) {
+	app := newTestApp(t)
+	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
+	body := bytes.NewBufferString(`{"created_at":"2026-01-01T00:00:00Z"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/books/"+bookID+"/reads", body)
+	resp := httptest.NewRecorder()
+
+	app.handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, resp.Code, resp.Body.String())
+	}
+}
+
+func TestReadAPICreateReturns404ForUnknownBook(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/books/"+uuid.NewString()+"/reads", bytes.NewBufferString(`{}`))
+	resp := httptest.NewRecorder()
+
+	app.handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNotFound, resp.Code, resp.Body.String())
+	}
+}
+
+func TestReadAPICreateRejectsInvalidValues(t *testing.T) {
+	tests := []string{
+		`{"started_at":"not-a-date"}`,
+		`{"started_at":"2026-02-02","finished_at":"2026-02-01"}`,
+		`{"rating":0.5}`,
+		`{"rating":4.2}`,
+		`{"rating":5.5}`,
+	}
+	for _, body := range tests {
+		t.Run(body, func(t *testing.T) {
+			app := newTestApp(t)
+			bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
+			req := httptest.NewRequest(http.MethodPost, "/api/books/"+bookID+"/reads", bytes.NewBufferString(body))
+			resp := httptest.NewRecorder()
+
+			app.handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+// ── List ──────────────────────────────────────────────────────────────────────
+
+func TestReadAPIList(t *testing.T) {
+	app := newTestApp(t)
+	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
+	testsupport.InsertReadRow(t, app.db, testsupport.ReadRow{
+		ID: "older", BookID: bookID, StartedAt: new("2025-01-01"), FinishedAt: new("2025-01-03"),
+		Rating: new(4.0), Notes: new("Good"), CreatedAt: "2026-01-01T00:00:00Z",
+	})
+	testsupport.InsertReadRow(t, app.db, testsupport.ReadRow{
+		ID: "newer", BookID: bookID, StartedAt: new("2026-01-01"), FinishedAt: new("2026-01-03"),
+		Rating: new(4.5), Notes: new("Excellent"), CreatedAt: "2026-01-02T00:00:00Z",
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/books/"+bookID+"/reads", nil)
+	resp := httptest.NewRecorder()
+
+	app.handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, resp.Code, resp.Body.String())
+	}
+
+	var raw []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != 2 || raw[0]["id"] != "newer" || raw[1]["id"] != "older" {
+		t.Fatalf("expected newest reads first, got %#v", raw)
+	}
+	for _, item := range raw {
+		for _, field := range []string{"id", "started_at", "finished_at", "rating", "notes"} {
+			if _, exists := item[field]; !exists {
+				t.Fatalf("expected field %q in %#v", field, item)
+			}
+		}
+		if _, exists := item["book_id"]; exists {
+			t.Fatal("book_id must not be exposed by the scoped list endpoint")
+		}
+		if _, exists := item["created_at"]; exists {
+			t.Fatal("created_at must not be exposed")
+		}
+		if _, exists := item["updated_at"]; exists {
+			t.Fatal("updated_at must not be exposed")
+		}
+	}
+}
+
+func TestReadAPIListReturnsEmptyArray(t *testing.T) {
+	app := newTestApp(t)
+	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/books/"+bookID+"/reads", nil)
+	resp := httptest.NewRecorder()
+
+	app.handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK || resp.Body.String() != "[]\n" {
+		t.Fatalf("expected empty JSON array, got status %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestReadAPIListReturns404ForUnknownBook(t *testing.T) {
+	app := newTestApp(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/books/"+uuid.NewString()+"/reads", nil)
+	resp := httptest.NewRecorder()
+
+	app.handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, resp.Code)
+	}
+}

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -7,6 +7,7 @@ import (
 	"bakku.dev/bookist/internal/authors"
 	"bakku.dev/bookist/internal/books"
 	"bakku.dev/bookist/internal/lists"
+	"bakku.dev/bookist/internal/reads"
 	"bakku.dev/bookist/internal/web"
 )
 
@@ -14,10 +15,11 @@ type Server struct {
 	books     *books.Service
 	authors   *authors.Service
 	lists     *lists.Service
+	reads     *reads.Service
 	templates *template.Template
 }
 
-func New(books *books.Service, authors *authors.Service, lists *lists.Service) (*Server, error) {
+func New(books *books.Service, authors *authors.Service, lists *lists.Service, reads *reads.Service) (*Server, error) {
 	templates, err := web.Templates()
 	if err != nil {
 		return nil, err
@@ -27,6 +29,7 @@ func New(books *books.Service, authors *authors.Service, lists *lists.Service) (
 		books:     books,
 		authors:   authors,
 		lists:     lists,
+		reads:     reads,
 		templates: templates,
 	}, nil
 }
@@ -37,6 +40,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /", s.handleIndex)
 	mux.HandleFunc("GET /api/books", s.handleAPIListBooks)
 	mux.HandleFunc("POST /api/books", s.handleAPICreateBook)
+	mux.HandleFunc("GET /api/books/{id}/reads", s.handleAPIListReads)
+	mux.HandleFunc("POST /api/books/{id}/reads", s.handleAPICreateRead)
 	mux.HandleFunc("GET /api/authors", s.handleAPIListAuthors)
 	mux.HandleFunc("POST /api/authors", s.handleAPICreateAuthor)
 	mux.HandleFunc("GET /api/lists", s.handleAPIListLists)

--- a/internal/httpserver/server_test.go
+++ b/internal/httpserver/server_test.go
@@ -9,6 +9,7 @@ import (
 	"bakku.dev/bookist/internal/books"
 	"bakku.dev/bookist/internal/httpserver"
 	"bakku.dev/bookist/internal/lists"
+	"bakku.dev/bookist/internal/reads"
 	"bakku.dev/bookist/internal/testsupport"
 )
 
@@ -31,7 +32,10 @@ func newTestApp(t *testing.T) testApp {
 	bookRepo := books.NewSQLiteRepository(db)
 	bookService := books.NewService(bookRepo, authorRepo)
 
-	server, err := httpserver.New(bookService, authorService, listService)
+	readRepo := reads.NewSQLiteRepository(db)
+	readService := reads.NewService(readRepo)
+
+	server, err := httpserver.New(bookService, authorService, listService, readService)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/reads/read.go
+++ b/internal/reads/read.go
@@ -1,0 +1,29 @@
+package reads
+
+import "time"
+
+type Read struct {
+	ID         string    `json:"id"`
+	BookID     string    `json:"book_id"`
+	StartedAt  *string   `json:"started_at"`
+	FinishedAt *string   `json:"finished_at"`
+	Rating     *float64  `json:"rating"`
+	Notes      *string   `json:"notes"`
+	CreatedAt  time.Time `json:"-"`
+	UpdatedAt  time.Time `json:"-"`
+}
+
+type CreateReadRequest struct {
+	StartedAt  *string  `json:"started_at"`
+	FinishedAt *string  `json:"finished_at"`
+	Rating     *float64 `json:"rating"`
+	Notes      *string  `json:"notes"`
+}
+
+type ListItem struct {
+	ID         string   `json:"id"`
+	StartedAt  *string  `json:"started_at"`
+	FinishedAt *string  `json:"finished_at"`
+	Rating     *float64 `json:"rating"`
+	Notes      *string  `json:"notes"`
+}

--- a/internal/reads/service.go
+++ b/internal/reads/service.go
@@ -1,0 +1,84 @@
+package reads
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"time"
+)
+
+var ErrBookNotFound = errors.New("book not found")
+var ErrInvalidStartedAt = errors.New("started_at must be a date in YYYY-MM-DD format")
+var ErrInvalidFinishedAt = errors.New("finished_at must be a date in YYYY-MM-DD format")
+var ErrFinishedBeforeStarted = errors.New("finished_at must not be before started_at")
+var ErrInvalidRating = errors.New("rating must be between 1 and 5 in increments of 0.5")
+
+type Repository interface {
+	Create(ctx context.Context, bookID string, input CreateReadRequest) (Read, error)
+	ListByBookID(ctx context.Context, bookID string) ([]Read, error)
+}
+
+type Service struct {
+	repository Repository
+}
+
+func NewService(repository Repository) *Service {
+	return &Service{repository: repository}
+}
+
+func (s *Service) Create(ctx context.Context, bookID string, input CreateReadRequest) (Read, error) {
+	startedAt, err := normalizeDate(input.StartedAt, ErrInvalidStartedAt)
+	if err != nil {
+		return Read{}, err
+	}
+	input.StartedAt = startedAt
+
+	finishedAt, err := normalizeDate(input.FinishedAt, ErrInvalidFinishedAt)
+	if err != nil {
+		return Read{}, err
+	}
+	input.FinishedAt = finishedAt
+
+	if input.StartedAt != nil && input.FinishedAt != nil && *input.FinishedAt < *input.StartedAt {
+		return Read{}, ErrFinishedBeforeStarted
+	}
+
+	if input.Rating != nil {
+		rating := *input.Rating
+		if math.IsNaN(rating) || math.IsInf(rating, 0) || rating < 1 || rating > 5 || math.Mod(rating*2, 1) != 0 {
+			return Read{}, ErrInvalidRating
+		}
+	}
+
+	if input.Notes != nil {
+		notes := strings.TrimSpace(*input.Notes)
+		if notes == "" {
+			input.Notes = nil
+		} else {
+			input.Notes = &notes
+		}
+	}
+
+	return s.repository.Create(ctx, bookID, input)
+}
+
+func (s *Service) ListByBookID(ctx context.Context, bookID string) ([]Read, error) {
+	return s.repository.ListByBookID(ctx, bookID)
+}
+
+func normalizeDate(value *string, invalidError error) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	date := strings.TrimSpace(*value)
+	if date == "" {
+		return nil, nil
+	}
+	if _, err := time.Parse(time.DateOnly, date); err != nil {
+		return nil, invalidError
+	}
+
+	return &date, nil
+}

--- a/internal/reads/service_test.go
+++ b/internal/reads/service_test.go
@@ -1,0 +1,112 @@
+package reads_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"bakku.dev/bookist/internal/reads"
+	"bakku.dev/bookist/internal/testsupport"
+)
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestServiceCreateNormalizesInput(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+	service := reads.NewService(reads.NewSQLiteRepository(db))
+	startedAt := " 2026-01-02 "
+	finishedAt := "2026-01-03"
+	rating := 4.5
+	notes := "  Excellent  "
+
+	created, err := service.Create(context.Background(), bookID, reads.CreateReadRequest{
+		StartedAt: &startedAt, FinishedAt: &finishedAt, Rating: &rating, Notes: &notes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.StartedAt == nil || *created.StartedAt != "2026-01-02" {
+		t.Fatalf("expected normalized started_at, got %#v", created.StartedAt)
+	}
+	if created.Notes == nil || *created.Notes != "Excellent" {
+		t.Fatalf("expected normalized notes, got %#v", created.Notes)
+	}
+}
+
+func TestServiceCreateNormalizesEmptyOptionalStringsToNull(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+	service := reads.NewService(reads.NewSQLiteRepository(db))
+	empty := "  "
+
+	created, err := service.Create(context.Background(), bookID, reads.CreateReadRequest{
+		StartedAt: &empty, FinishedAt: &empty, Notes: &empty,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.StartedAt != nil || created.FinishedAt != nil || created.Notes != nil {
+		t.Fatalf("expected empty optional values to become nil, got %#v", created)
+	}
+}
+
+func TestServiceCreateRejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input reads.CreateReadRequest
+		want  error
+	}{
+		{name: "invalid started date", input: reads.CreateReadRequest{StartedAt: new("01/02/2026")}, want: reads.ErrInvalidStartedAt},
+		{name: "invalid finished date", input: reads.CreateReadRequest{FinishedAt: new("2026-02-30")}, want: reads.ErrInvalidFinishedAt},
+		{name: "finished before started", input: reads.CreateReadRequest{StartedAt: new("2026-02-02"), FinishedAt: new("2026-02-01")}, want: reads.ErrFinishedBeforeStarted},
+		{name: "rating below range", input: reads.CreateReadRequest{Rating: new(0.5)}, want: reads.ErrInvalidRating},
+		{name: "rating above range", input: reads.CreateReadRequest{Rating: new(5.5)}, want: reads.ErrInvalidRating},
+		{name: "rating wrong increment", input: reads.CreateReadRequest{Rating: new(4.2)}, want: reads.ErrInvalidRating},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db := testsupport.OpenMigratedDB(t)
+			bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+			service := reads.NewService(reads.NewSQLiteRepository(db))
+
+			_, err := service.Create(context.Background(), bookID, test.input)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("expected %v, got %v", test.want, err)
+			}
+
+			var count int
+			if err := db.QueryRow(`SELECT COUNT(*) FROM reads`).Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 0 {
+				t.Fatalf("expected no persisted reads, got %d", count)
+			}
+		})
+	}
+}
+
+// ── ListByBookID ──────────────────────────────────────────────────────────────
+
+func TestServiceListByBookIDReturnsReads(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+	testsupport.InsertReadRow(t, db, testsupport.ReadRow{
+		ID: "read-1", BookID: bookID, StartedAt: new("2026-01-01"),
+		FinishedAt: new("2026-01-03"), Rating: new(4.5), Notes: new("Excellent"),
+		CreatedAt: "2026-01-04T00:00:00Z",
+	})
+	service := reads.NewService(reads.NewSQLiteRepository(db))
+
+	listed, err := service.ListByBookID(context.Background(), bookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 read, got %d", len(listed))
+	}
+	if listed[0].ID != "read-1" || listed[0].Rating == nil || *listed[0].Rating != 4.5 {
+		t.Fatalf("unexpected read: %#v", listed[0])
+	}
+}

--- a/internal/reads/sqlite_repository.go
+++ b/internal/reads/sqlite_repository.go
@@ -1,0 +1,138 @@
+package reads
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type SQLiteRepository struct {
+	db *sql.DB
+}
+
+func NewSQLiteRepository(db *sql.DB) *SQLiteRepository {
+	return &SQLiteRepository{db: db}
+}
+
+func (r *SQLiteRepository) Create(ctx context.Context, bookID string, input CreateReadRequest) (Read, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	row := r.db.QueryRowContext(ctx, `
+		INSERT INTO reads (
+			id, book_id, started_at, finished_at, rating, notes, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING id, book_id, started_at, finished_at, rating, notes, created_at, updated_at
+	`, uuid.NewString(), bookID, nullString(input.StartedAt), nullString(input.FinishedAt),
+		nullFloat64(input.Rating), nullString(input.Notes), now, now)
+
+	read, err := scanRead(row)
+	if err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+			return Read{}, ErrBookNotFound
+		}
+		return Read{}, err
+	}
+
+	return read, nil
+}
+
+func (r *SQLiteRepository) ListByBookID(ctx context.Context, bookID string) ([]Read, error) {
+	var exists int
+	if err := r.db.QueryRowContext(ctx, `SELECT 1 FROM books WHERE id = ?`, bookID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrBookNotFound
+		}
+		return nil, err
+	}
+
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, book_id, started_at, finished_at, rating, notes, created_at, updated_at
+		FROM reads
+		WHERE book_id = ?
+		ORDER BY finished_at DESC, started_at DESC, created_at DESC
+	`, bookID)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	result := make([]Read, 0)
+	for rows.Next() {
+		read, err := scanRead(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, read)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+type readScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRead(scanner readScanner) (Read, error) {
+	var result Read
+	var startedAt sql.NullString
+	var finishedAt sql.NullString
+	var rating sql.NullFloat64
+	var notes sql.NullString
+	var createdAt string
+	var updatedAt string
+
+	if err := scanner.Scan(&result.ID, &result.BookID, &startedAt, &finishedAt, &rating, &notes, &createdAt, &updatedAt); err != nil {
+		return Read{}, err
+	}
+
+	if startedAt.Valid {
+		result.StartedAt = &startedAt.String
+	}
+	if finishedAt.Valid {
+		result.FinishedAt = &finishedAt.String
+	}
+	if rating.Valid {
+		result.Rating = &rating.Float64
+	}
+	if notes.Valid {
+		result.Notes = &notes.String
+	}
+
+	var err error
+	result.CreatedAt, err = time.Parse(time.RFC3339, createdAt)
+	if err != nil {
+		return Read{}, fmt.Errorf("parse created_at: %w", err)
+	}
+	result.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt)
+	if err != nil {
+		return Read{}, fmt.Errorf("parse updated_at: %w", err)
+	}
+
+	return result, nil
+}
+
+func nullString(value *string) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *value, Valid: true}
+}
+
+func nullFloat64(value *float64) sql.NullFloat64 {
+	if value == nil {
+		return sql.NullFloat64{}
+	}
+	return sql.NullFloat64{Float64: *value, Valid: true}
+}

--- a/internal/reads/sqlite_repository_test.go
+++ b/internal/reads/sqlite_repository_test.go
@@ -1,0 +1,148 @@
+package reads_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"bakku.dev/bookist/internal/reads"
+	"bakku.dev/bookist/internal/testsupport"
+	"github.com/google/uuid"
+)
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestSQLiteRepositoryCreatePersistsRead(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+	repository := reads.NewSQLiteRepository(db)
+	startedAt := "2026-01-01"
+	finishedAt := "2026-01-03"
+	rating := 4.5
+	notes := "Excellent"
+
+	created, err := repository.Create(context.Background(), bookID, reads.CreateReadRequest{
+		StartedAt: &startedAt, FinishedAt: &finishedAt, Rating: &rating, Notes: &notes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := uuid.Parse(created.ID); err != nil {
+		t.Fatalf("expected UUID read ID, got %q", created.ID)
+	}
+	if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
+		t.Fatal("expected backend timestamps")
+	}
+
+	var gotBookID string
+	var gotStartedAt, gotFinishedAt, gotNotes sql.NullString
+	var gotRating sql.NullFloat64
+	var createdAt, updatedAt string
+	err = db.QueryRow(`
+		SELECT book_id, started_at, finished_at, rating, notes, created_at, updated_at
+		FROM reads WHERE id = ?
+	`, created.ID).Scan(&gotBookID, &gotStartedAt, &gotFinishedAt, &gotRating, &gotNotes, &createdAt, &updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBookID != bookID || gotStartedAt.String != startedAt || gotFinishedAt.String != finishedAt || gotRating.Float64 != rating || gotNotes.String != notes {
+		t.Fatalf("unexpected persisted read values")
+	}
+	if _, err := time.Parse(time.RFC3339, createdAt); err != nil {
+		t.Fatalf("invalid created_at: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, updatedAt); err != nil {
+		t.Fatalf("invalid updated_at: %v", err)
+	}
+}
+
+func TestSQLiteRepositoryCreateReturnsBookNotFound(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	repository := reads.NewSQLiteRepository(db)
+
+	_, err := repository.Create(context.Background(), uuid.NewString(), reads.CreateReadRequest{})
+	if !errors.Is(err, reads.ErrBookNotFound) {
+		t.Fatalf("expected ErrBookNotFound, got %v", err)
+	}
+}
+
+// ── ListByBookID ──────────────────────────────────────────────────────────────
+
+func TestSQLiteRepositoryListByBookIDOrdersNewestFirst(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+	otherBookID := testsupport.InsertBookRow(t, db, "Foundation", nil)
+	testsupport.InsertReadRow(t, db, testsupport.ReadRow{
+		ID: "old", BookID: bookID, StartedAt: new("2025-01-01"), FinishedAt: new("2025-01-02"),
+		CreatedAt: "2026-01-01T00:00:00Z",
+	})
+	testsupport.InsertReadRow(t, db, testsupport.ReadRow{
+		ID: "new", BookID: bookID, StartedAt: new("2026-01-01"), FinishedAt: new("2026-01-02"),
+		CreatedAt: "2026-01-02T00:00:00Z",
+	})
+	testsupport.InsertReadRow(t, db, testsupport.ReadRow{
+		ID: "other", BookID: otherBookID, StartedAt: new("2027-01-01"), FinishedAt: new("2027-01-02"),
+		CreatedAt: "2027-01-02T00:00:00Z",
+	})
+
+	listed, err := reads.NewSQLiteRepository(db).ListByBookID(context.Background(), bookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 2 || listed[0].ID != "new" || listed[1].ID != "old" {
+		t.Fatalf("expected newest reads first, got %#v", listed)
+	}
+}
+
+func TestSQLiteRepositoryListByBookIDReturnsEmptySlice(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+
+	listed, err := reads.NewSQLiteRepository(db).ListByBookID(context.Background(), bookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listed == nil || len(listed) != 0 {
+		t.Fatalf("expected empty non-nil slice, got %#v", listed)
+	}
+}
+
+func TestSQLiteRepositoryListByBookIDReturnsBookNotFound(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+
+	_, err := reads.NewSQLiteRepository(db).ListByBookID(context.Background(), uuid.NewString())
+	if !errors.Is(err, reads.ErrBookNotFound) {
+		t.Fatalf("expected ErrBookNotFound, got %v", err)
+	}
+}
+
+// ── Constraints ───────────────────────────────────────────────────────────────
+
+func TestReadsTableEnforcesRatingAndDateConstraints(t *testing.T) {
+	db := testsupport.OpenMigratedDB(t)
+	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
+	now := "2026-01-01T00:00:00Z"
+
+	for _, test := range []struct {
+		name       string
+		startedAt  string
+		finishedAt string
+		rating     float64
+	}{
+		{name: "rating range", startedAt: "2026-01-01", finishedAt: "2026-01-02", rating: 5.5},
+		{name: "rating increment", startedAt: "2026-01-01", finishedAt: "2026-01-02", rating: 4.2},
+		{name: "date order", startedAt: "2026-01-02", finishedAt: "2026-01-01", rating: 4.5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := db.Exec(`
+				INSERT INTO reads (id, book_id, started_at, finished_at, rating, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+			`, uuid.NewString(), bookID, test.startedAt, test.finishedAt, test.rating, now, now)
+			if err == nil {
+				t.Fatal("expected database constraint error")
+			}
+		})
+	}
+}

--- a/internal/testsupport/authors.go
+++ b/internal/testsupport/authors.go
@@ -1,0 +1,67 @@
+package testsupport
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func InsertAuthorRow(t testing.TB, db *sql.DB, name string) string {
+	t.Helper()
+
+	now := "2026-01-02T03:04:05Z"
+	id := uuid.NewString()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO authors (id, name, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+	`, id, name, now, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return id
+}
+
+func AssertAuthorRow(t testing.TB, db *sql.DB, id string, wantName string) {
+	t.Helper()
+
+	var name string
+	var createdAt string
+	var updatedAt string
+	err := db.QueryRowContext(context.Background(), `
+		SELECT name, created_at, updated_at
+		FROM authors
+		WHERE id = ?
+	`, id).Scan(&name, &createdAt, &updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if name != wantName {
+		t.Fatalf("expected persisted name %q, got %q", wantName, name)
+	}
+
+	if _, err := time.Parse(time.RFC3339, createdAt); err != nil {
+		t.Fatalf("expected RFC3339 created_at, got %q", createdAt)
+	}
+
+	if _, err := time.Parse(time.RFC3339, updatedAt); err != nil {
+		t.Fatalf("expected RFC3339 updated_at, got %q", updatedAt)
+	}
+}
+
+func AssertAuthorCount(t testing.TB, db *sql.DB, want int) {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM authors`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+
+	if count != want {
+		t.Fatalf("expected %d persisted authors, got %d", want, count)
+	}
+}

--- a/internal/testsupport/books.go
+++ b/internal/testsupport/books.go
@@ -3,31 +3,13 @@ package testsupport
 import (
 	"context"
 	"database/sql"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"bakku.dev/bookist/internal/authors"
 	"bakku.dev/bookist/internal/books"
-	"bakku.dev/bookist/internal/database"
 	"github.com/google/uuid"
 )
-
-func OpenMigratedDB(t testing.TB) *sql.DB {
-	t.Helper()
-
-	db, err := database.Open(context.Background(), filepath.Join(t.TempDir(), "bookist.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	if err := database.MigrateUp(db); err != nil {
-		t.Fatal(err)
-	}
-
-	return db
-}
 
 func NewBookService(t testing.TB) (*books.Service, *sql.DB) {
 	t.Helper()
@@ -198,63 +180,6 @@ func AssertBookCount(t testing.TB, db *sql.DB, want int) {
 	}
 }
 
-func InsertAuthorRow(t testing.TB, db *sql.DB, name string) string {
-	t.Helper()
-
-	now := "2026-01-02T03:04:05Z"
-	id := uuid.NewString()
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO authors (id, name, created_at, updated_at)
-		VALUES (?, ?, ?, ?)
-	`, id, name, now, now)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return id
-}
-
-func AssertAuthorRow(t testing.TB, db *sql.DB, id string, wantName string) {
-	t.Helper()
-
-	var name string
-	var createdAt string
-	var updatedAt string
-	err := db.QueryRowContext(context.Background(), `
-		SELECT name, created_at, updated_at
-		FROM authors
-		WHERE id = ?
-	`, id).Scan(&name, &createdAt, &updatedAt)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if name != wantName {
-		t.Fatalf("expected persisted name %q, got %q", wantName, name)
-	}
-
-	if _, err := time.Parse(time.RFC3339, createdAt); err != nil {
-		t.Fatalf("expected RFC3339 created_at, got %q", createdAt)
-	}
-
-	if _, err := time.Parse(time.RFC3339, updatedAt); err != nil {
-		t.Fatalf("expected RFC3339 updated_at, got %q", updatedAt)
-	}
-}
-
-func AssertAuthorCount(t testing.TB, db *sql.DB, want int) {
-	t.Helper()
-
-	var count int
-	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM authors`).Scan(&count); err != nil {
-		t.Fatal(err)
-	}
-
-	if count != want {
-		t.Fatalf("expected %d persisted authors, got %d", want, count)
-	}
-}
-
 func InsertBookAuthorRow(t testing.TB, db *sql.DB, bookID string, authorID string) {
 	t.Helper()
 
@@ -306,119 +231,5 @@ func AssertBookAuthors(t testing.TB, db *sql.DB, bookID string, wantAuthorIDs ..
 		if !gotSet[want] {
 			t.Fatalf("expected author_id %q not found in book_authors", want)
 		}
-	}
-}
-
-func InsertListRow(t testing.TB, db *sql.DB, name string) string {
-	t.Helper()
-
-	now := "2026-01-02T03:04:05Z"
-	id := uuid.NewString()
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO lists (id, name, created_at, updated_at)
-		VALUES (?, ?, ?, ?)
-	`, id, name, now, now)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return id
-}
-
-func InsertListRowWithDescription(t testing.TB, db *sql.DB, name string, description string) string {
-	t.Helper()
-
-	now := "2026-01-02T03:04:05Z"
-	id := uuid.NewString()
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO lists (id, name, description, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, id, name, description, now, now)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return id
-}
-
-func AssertListRow(t testing.TB, db *sql.DB, id string, wantName string) {
-	t.Helper()
-
-	var name string
-	var createdAt string
-	var updatedAt string
-	err := db.QueryRowContext(context.Background(), `
-		SELECT name, created_at, updated_at
-		FROM lists
-		WHERE id = ?
-	`, id).Scan(&name, &createdAt, &updatedAt)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if name != wantName {
-		t.Fatalf("expected persisted name %q, got %q", wantName, name)
-	}
-
-	if _, err := time.Parse(time.RFC3339, createdAt); err != nil {
-		t.Fatalf("expected RFC3339 created_at, got %q", createdAt)
-	}
-
-	if _, err := time.Parse(time.RFC3339, updatedAt); err != nil {
-		t.Fatalf("expected RFC3339 updated_at, got %q", updatedAt)
-	}
-}
-
-func AssertListCount(t testing.TB, db *sql.DB, want int) {
-	t.Helper()
-
-	var count int
-	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM lists`).Scan(&count); err != nil {
-		t.Fatal(err)
-	}
-	if count != want {
-		t.Fatalf("expected %d persisted lists, got %d", want, count)
-	}
-}
-
-func InsertBookListRow(t testing.TB, db *sql.DB, listID string, bookID string) {
-	t.Helper()
-
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO book_lists (list_id, book_id)
-		VALUES (?, ?)
-	`, listID, bookID)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func AssertBookListRow(t testing.TB, db *sql.DB, listID string, bookID string) {
-	t.Helper()
-
-	var count int
-	err := db.QueryRowContext(context.Background(), `
-		SELECT COUNT(*) FROM book_lists WHERE list_id = ? AND book_id = ?
-	`, listID, bookID).Scan(&count)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if count != 1 {
-		t.Fatalf("expected 1 book_lists row for list %s book %s, got %d", listID, bookID, count)
-	}
-}
-
-func AssertBookListCount(t testing.TB, db *sql.DB, listID string, want int) {
-	t.Helper()
-
-	var count int
-	err := db.QueryRowContext(context.Background(), `
-		SELECT COUNT(*) FROM book_lists WHERE list_id = ?
-	`, listID).Scan(&count)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if count != want {
-		t.Fatalf("expected %d book_lists rows for list %s, got %d", want, listID, count)
 	}
 }

--- a/internal/testsupport/database.go
+++ b/internal/testsupport/database.go
@@ -1,0 +1,26 @@
+package testsupport
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"bakku.dev/bookist/internal/database"
+)
+
+func OpenMigratedDB(t testing.TB) *sql.DB {
+	t.Helper()
+
+	db, err := database.Open(context.Background(), filepath.Join(t.TempDir(), "bookist.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := database.MigrateUp(db); err != nil {
+		t.Fatal(err)
+	}
+
+	return db
+}

--- a/internal/testsupport/lists.go
+++ b/internal/testsupport/lists.go
@@ -1,0 +1,124 @@
+package testsupport
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func InsertListRow(t testing.TB, db *sql.DB, name string) string {
+	t.Helper()
+
+	now := "2026-01-02T03:04:05Z"
+	id := uuid.NewString()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO lists (id, name, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+	`, id, name, now, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return id
+}
+
+func InsertListRowWithDescription(t testing.TB, db *sql.DB, name string, description string) string {
+	t.Helper()
+
+	now := "2026-01-02T03:04:05Z"
+	id := uuid.NewString()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO lists (id, name, description, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, id, name, description, now, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return id
+}
+
+func AssertListRow(t testing.TB, db *sql.DB, id string, wantName string) {
+	t.Helper()
+
+	var name string
+	var createdAt string
+	var updatedAt string
+	err := db.QueryRowContext(context.Background(), `
+		SELECT name, created_at, updated_at
+		FROM lists
+		WHERE id = ?
+	`, id).Scan(&name, &createdAt, &updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if name != wantName {
+		t.Fatalf("expected persisted name %q, got %q", wantName, name)
+	}
+
+	if _, err := time.Parse(time.RFC3339, createdAt); err != nil {
+		t.Fatalf("expected RFC3339 created_at, got %q", createdAt)
+	}
+
+	if _, err := time.Parse(time.RFC3339, updatedAt); err != nil {
+		t.Fatalf("expected RFC3339 updated_at, got %q", updatedAt)
+	}
+}
+
+func AssertListCount(t testing.TB, db *sql.DB, want int) {
+	t.Helper()
+
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM lists`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != want {
+		t.Fatalf("expected %d persisted lists, got %d", want, count)
+	}
+}
+
+func InsertBookListRow(t testing.TB, db *sql.DB, listID string, bookID string) {
+	t.Helper()
+
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO book_lists (list_id, book_id)
+		VALUES (?, ?)
+	`, listID, bookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func AssertBookListRow(t testing.TB, db *sql.DB, listID string, bookID string) {
+	t.Helper()
+
+	var count int
+	err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*) FROM book_lists WHERE list_id = ? AND book_id = ?
+	`, listID, bookID).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 book_lists row for list %s book %s, got %d", listID, bookID, count)
+	}
+}
+
+func AssertBookListCount(t testing.TB, db *sql.DB, listID string, want int) {
+	t.Helper()
+
+	var count int
+	err := db.QueryRowContext(context.Background(), `
+		SELECT COUNT(*) FROM book_lists WHERE list_id = ?
+	`, listID).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != want {
+		t.Fatalf("expected %d book_lists rows for list %s, got %d", want, listID, count)
+	}
+}

--- a/internal/testsupport/reads.go
+++ b/internal/testsupport/reads.go
@@ -1,0 +1,29 @@
+package testsupport
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+type ReadRow struct {
+	ID         string
+	BookID     string
+	StartedAt  *string
+	FinishedAt *string
+	Rating     *float64
+	Notes      *string
+	CreatedAt  string
+}
+
+func InsertReadRow(t testing.TB, db *sql.DB, row ReadRow) {
+	t.Helper()
+
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO reads (id, book_id, started_at, finished_at, rating, notes, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, row.ID, row.BookID, row.StartedAt, row.FinishedAt, row.Rating, row.Notes, row.CreatedAt, row.CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Record individual reading activity for books with optional dates, half-step ratings, and notes while keeping audit timestamps backend-managed.

- Add the reads schema, repository, validation service, and nested book API endpoints
- Add reads list and add CLI commands with title or UUID book resolution
- Cover persistence, constraints, HTTP behavior, output formats, and error handling