### PR TITLE
Allow duplicate book titles and author names

### DIFF
--- a/internal/authors/service.go
+++ b/internal/authors/service.go
@@ -7,12 +7,10 @@ import (
 )
 
 var ErrNameRequired = errors.New("name is required")
-var ErrNameConflict = errors.New("an author with this name already exists")
 
 type Repository interface {
 	Create(ctx context.Context, input CreateAuthorRequest) (Author, error)
 	List(ctx context.Context) ([]Author, error)
-	NameExists(ctx context.Context, name string) (bool, error)
 	GetByIDs(ctx context.Context, ids []string) ([]Author, error)
 	ListByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error)
 }
@@ -29,15 +27,6 @@ func (s *Service) Create(ctx context.Context, input CreateAuthorRequest) (Author
 	input.Name = strings.TrimSpace(input.Name)
 	if input.Name == "" {
 		return Author{}, ErrNameRequired
-	}
-
-	exists, err := s.repository.NameExists(ctx, input.Name)
-	if err != nil {
-		return Author{}, err
-	}
-
-	if exists {
-		return Author{}, ErrNameConflict
 	}
 
 	return s.repository.Create(ctx, input)

--- a/internal/authors/service_test.go
+++ b/internal/authors/service_test.go
@@ -36,19 +36,6 @@ func TestServiceCreateTrimsAndPersistsName(t *testing.T) {
 	testsupport.AssertAuthorRow(t, db, created.ID, "Jane Austen")
 }
 
-func TestServiceCreateRejectsCaseInsensitiveDuplicate(t *testing.T) {
-	db := testsupport.OpenMigratedDB(t)
-	service := authors.NewService(authors.NewSQLiteRepository(db))
-
-	if _, err := service.Create(context.Background(), authors.CreateAuthorRequest{Name: "Jane Austen"}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := service.Create(context.Background(), authors.CreateAuthorRequest{Name: "jane AUSTEN"}); !errors.Is(err, authors.ErrNameConflict) {
-		t.Fatalf("expected ErrNameConflict, got %v", err)
-	}
-	testsupport.AssertAuthorCount(t, db, 1)
-}
-
 // ── List ──────────────────────────────────────────────────────────────────────
 
 func TestServiceListDelegates(t *testing.T) {

--- a/internal/authors/sqlite_repository.go
+++ b/internal/authors/sqlite_repository.go
@@ -29,17 +29,7 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateAuthorRequest
 		RETURNING id, name, created_at, updated_at
 	`, uuid.NewString(), input.Name, createdAt, updatedAt)
 
-	author, err := scanAuthor(row)
-	if err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed: authors.name") {
-		return Author{}, ErrNameConflict
-	}
-	return author, err
-}
-
-func (r *SQLiteRepository) NameExists(ctx context.Context, name string) (bool, error) {
-	var exists bool
-	err := r.db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM authors WHERE name = ? COLLATE NOCASE)`, name).Scan(&exists)
-	return exists, err
+	return scanAuthor(row)
 }
 
 func (r *SQLiteRepository) List(ctx context.Context) ([]Author, error) {

--- a/internal/books/service.go
+++ b/internal/books/service.go
@@ -12,7 +12,6 @@ import (
 )
 
 var ErrTitleRequired = errors.New("title is required")
-var ErrTitleConflict = errors.New("a book with this title already exists")
 var ErrAuthorNotFound = errors.New("author not found")
 var ErrInvalidFormat = errors.New("format must be one of: hardback, paperback, epub")
 var ErrInvalidPurchasedAt = errors.New("purchased_at must be a date in YYYY-MM-DD format")
@@ -26,7 +25,6 @@ var ErrInvalidPublishedDay = errors.New("published_day must form a valid date an
 type Repository interface {
 	List(ctx context.Context) ([]Book, error)
 	ListByListID(ctx context.Context, listID string) ([]Book, error)
-	TitleExists(ctx context.Context, title string) (bool, error)
 	Create(ctx context.Context, input CreateBookRequest) (Book, error)
 }
 
@@ -105,15 +103,6 @@ func (s *Service) Create(ctx context.Context, input CreateBookRequest) (Book, er
 	input.Title = strings.TrimSpace(input.Title)
 	if input.Title == "" {
 		return Book{}, ErrTitleRequired
-	}
-
-	exists, err := s.repository.TitleExists(ctx, input.Title)
-	if err != nil {
-		return Book{}, err
-	}
-
-	if exists {
-		return Book{}, ErrTitleConflict
 	}
 
 	if input.ISBN != nil {

--- a/internal/books/service_test.go
+++ b/internal/books/service_test.go
@@ -370,18 +370,6 @@ func TestServiceCreateRejectsInvalidPurchasedAt(t *testing.T) {
 	testsupport.AssertBookCount(t, db, 0)
 }
 
-func TestServiceCreateRejectsCaseInsensitiveDuplicate(t *testing.T) {
-	service, db := testsupport.NewBookService(t)
-
-	if _, err := service.Create(context.Background(), books.CreateBookRequest{Title: "Dune"}); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := service.Create(context.Background(), books.CreateBookRequest{Title: "dUnE"}); !errors.Is(err, books.ErrTitleConflict) {
-		t.Fatalf("expected ErrTitleConflict, got %v", err)
-	}
-	testsupport.AssertBookCount(t, db, 1)
-}
-
 // ── List ──────────────────────────────────────────────────────────────────────
 
 func TestServiceListHydratesAuthors(t *testing.T) {

--- a/internal/books/sqlite_repository.go
+++ b/internal/books/sqlite_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
 
 	"bakku.dev/bookist/internal/authors"
@@ -84,12 +83,6 @@ func (r *SQLiteRepository) ListByListID(ctx context.Context, listID string) ([]B
 	}
 
 	return bookList, nil
-}
-
-func (r *SQLiteRepository) TitleExists(ctx context.Context, title string) (bool, error) {
-	var exists bool
-	err := r.db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM books WHERE title = ? COLLATE NOCASE)`, title).Scan(&exists)
-	return exists, err
 }
 
 func (r *SQLiteRepository) Create(ctx context.Context, input CreateBookRequest) (Book, error) {
@@ -210,9 +203,6 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateBookRequest) 
 
 	book, err := scanBook(row)
 	if err != nil {
-		if strings.Contains(err.Error(), "UNIQUE constraint failed: books.title") {
-			return Book{}, ErrTitleConflict
-		}
 		return Book{}, err
 	}
 

--- a/internal/cli/books.go
+++ b/internal/cli/books.go
@@ -261,7 +261,7 @@ func resolveAuthorIDs(serverURL string, values []string) ([]string, error) {
 	}
 
 	var result []string
-	var byName map[string]authors.Author
+	var byName map[string][]authors.Author
 
 	for _, val := range values {
 		val = strings.TrimSpace(val)
@@ -280,15 +280,21 @@ func resolveAuthorIDs(serverURL string, values []string) ([]string, error) {
 					return nil, fmt.Errorf("fetch authors: %v", err)
 				}
 
-				byName = make(map[string]authors.Author, len(existingAuthors))
+				byName = make(map[string][]authors.Author, len(existingAuthors))
 
 				for _, a := range existingAuthors {
-					byName[strings.ToLower(a.Name)] = a
+					key := strings.ToLower(a.Name)
+					byName[key] = append(byName[key], a)
 				}
 			}
 
-			if a, ok := byName[strings.ToLower(val)]; ok {
-				result = append(result, a.ID)
+			key := strings.ToLower(val)
+			matches := byName[key]
+			if len(matches) > 1 {
+				return nil, fmt.Errorf("author %q exists multiple times; pass an author ID instead", val)
+			}
+			if len(matches) == 1 {
+				result = append(result, matches[0].ID)
 			} else {
 				// Textual author references create the missing author for convenient book entry.
 				created, err := createAuthor(serverURL, val)
@@ -297,6 +303,7 @@ func resolveAuthorIDs(serverURL string, values []string) ([]string, error) {
 				}
 
 				result = append(result, created.ID)
+				byName[key] = []authors.Author{created}
 			}
 		}
 	}

--- a/internal/cli/books_test.go
+++ b/internal/cli/books_test.go
@@ -304,6 +304,35 @@ func TestBooksAddWithAuthorNameExistsLinksAuthor(t *testing.T) {
 	}
 }
 
+func TestBooksAddWithAmbiguousAuthorNameRequiresID(t *testing.T) {
+	bookPosted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/authors":
+			_ = json.NewEncoder(w).Encode([]authors.Author{
+				{ID: "author-1", Name: "Alex Smith"},
+				{ID: "author-2", Name: "alex SMITH"},
+			})
+		case "/api/books":
+			bookPosted = true
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr strings.Builder
+	exitCode := cli.Run([]string{"books", "add", "--title", "My Book", "--author", "Alex Smith", "--server", server.URL}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if bookPosted {
+		t.Fatal("expected ambiguous author to prevent book creation")
+	}
+	if !strings.Contains(stderr.String(), `author "Alex Smith" exists multiple times; pass an author ID instead`) {
+		t.Fatalf("unexpected error: %q", stderr.String())
+	}
+}
+
 func TestBooksAddWithAuthorNameNotFoundCreatesAuthorThenBook(t *testing.T) {
 	var postedAuthors []authors.CreateAuthorRequest
 	var postedBooks []books.CreateBookRequest

--- a/internal/cli/lists.go
+++ b/internal/cli/lists.go
@@ -269,15 +269,18 @@ func resolveBookID(serverURL, value string) (string, error) {
 		return "", fmt.Errorf("fetch books: %v", err)
 	}
 
-	byTitle := make(map[string]string)
+	byTitle := make(map[string][]string)
 	for _, b := range existing {
-		if _, exists := byTitle[strings.ToLower(b.Title)]; !exists {
-			byTitle[strings.ToLower(b.Title)] = b.ID
-		}
+		key := strings.ToLower(b.Title)
+		byTitle[key] = append(byTitle[key], b.ID)
 	}
 
-	if id, ok := byTitle[strings.ToLower(value)]; ok {
-		return id, nil
+	matches := byTitle[strings.ToLower(value)]
+	if len(matches) > 1 {
+		return "", fmt.Errorf("book %q exists multiple times; pass a book ID instead", value)
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
 	}
 
 	return "", fmt.Errorf("book not found: %s", value)

--- a/internal/cli/lists_test.go
+++ b/internal/cli/lists_test.go
@@ -200,6 +200,40 @@ func TestListsAddBookResolvesBookByTitle(t *testing.T) {
 	}
 }
 
+func TestListsAddBookWithAmbiguousTitleRequiresID(t *testing.T) {
+	bookPosted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/lists":
+			_ = json.NewEncoder(w).Encode([]lists.List{{ID: "list-1", Name: "Want to Buy"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/books":
+			_ = json.NewEncoder(w).Encode([]struct {
+				ID    string `json:"id"`
+				Title string `json:"title"`
+			}{
+				{ID: "book-1", Title: "Dune"},
+				{ID: "book-2", Title: "dUnE"},
+			})
+		case r.Method == http.MethodPost:
+			bookPosted = true
+		}
+	}))
+	defer server.Close()
+
+	var stdout, stderr strings.Builder
+	exitCode := cli.Run([]string{"lists", "add-book", "--list", "Want to Buy", "--book", "Dune", "--server", server.URL}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatal("expected non-zero exit code")
+	}
+	if bookPosted {
+		t.Fatal("expected ambiguous title to prevent adding a book")
+	}
+	if !strings.Contains(stderr.String(), `book "Dune" exists multiple times; pass a book ID instead`) {
+		t.Fatalf("unexpected error: %q", stderr.String())
+	}
+}
+
 func TestListsAddBookListNotFoundExitsNonZero(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/lists" {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -83,16 +83,9 @@ func TestInitialSchemaRejectsNonUUIDIDs(t *testing.T) {
 	}
 }
 
-func TestInitialSchemaEnforcesNaturalKeysAndBookValidation(t *testing.T) {
+func TestInitialSchemaEnforcesBookValidation(t *testing.T) {
 	db := testsupport.OpenMigratedDB(t)
 	now := "2026-01-02T03:04:05Z"
-
-	if _, err := db.Exec(`INSERT INTO authors (id, name, created_at, updated_at) VALUES (?, 'Jane Austen', ?, ?)`, uuid.NewString(), now, now); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec(`INSERT INTO authors (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`, uuid.NewString(), "jane AUSTEN", now, now); err == nil {
-		t.Fatal("expected case-insensitive duplicate author name to violate a constraint")
-	}
 
 	for _, test := range []struct {
 		title string
@@ -115,12 +108,6 @@ func TestInitialSchemaEnforcesNaturalKeysAndBookValidation(t *testing.T) {
 		if _, err := db.Exec(query, args...); err == nil {
 			t.Fatalf("expected %s to violate a constraint", test.title)
 		}
-	}
-	if _, err := db.Exec(`INSERT INTO books (id, title, created_at, updated_at) VALUES (?, 'Dune', ?, ?)`, uuid.NewString(), now, now); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.Exec(`INSERT INTO books (id, title, created_at, updated_at) VALUES (?, 'dUnE', ?, ?)`, uuid.NewString(), now, now); err == nil {
-		t.Fatal("expected case-insensitive duplicate title to violate a constraint")
 	}
 }
 

--- a/internal/database/migrations/00001_initial_tables.sql
+++ b/internal/database/migrations/00001_initial_tables.sql
@@ -6,7 +6,7 @@ CREATE TABLE books (
         substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
         length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
     ),
-    title TEXT NOT NULL COLLATE NOCASE UNIQUE CHECK (trim(title) <> ''),
+    title TEXT NOT NULL COLLATE NOCASE CHECK (trim(title) <> ''),
     isbn TEXT NULL,
     language TEXT NULL,
     publisher TEXT NULL,
@@ -56,7 +56,7 @@ CREATE TABLE authors (
         substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
         length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
     ),
-    name TEXT NOT NULL COLLATE NOCASE UNIQUE CHECK (trim(name) <> ''),
+    name TEXT NOT NULL COLLATE NOCASE CHECK (trim(name) <> ''),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/internal/httpserver/authors.go
+++ b/internal/httpserver/authors.go
@@ -42,10 +42,5 @@ func writeCreateAuthorError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if errors.Is(err, authors.ErrNameConflict) {
-		http.Error(w, err.Error(), http.StatusConflict)
-		return
-	}
-
 	http.Error(w, "failed to create author", http.StatusInternalServerError)
 }

--- a/internal/httpserver/authors_test.go
+++ b/internal/httpserver/authors_test.go
@@ -41,18 +41,6 @@ func TestAuthorAPICreate(t *testing.T) {
 	testsupport.AssertAuthorRow(t, app.db, created.ID, "Jane Austen")
 }
 
-func TestAuthorAPICreateReturnsConflictForDuplicateName(t *testing.T) {
-	app := newTestApp(t)
-	testsupport.InsertAuthorRow(t, app.db, "Jane Austen")
-
-	req := httptest.NewRequest(http.MethodPost, "/api/authors", bytes.NewBufferString(`{"name":"jane AUSTEN"}`))
-	resp := httptest.NewRecorder()
-	app.handler.ServeHTTP(resp, req)
-	if resp.Code != http.StatusConflict {
-		t.Fatalf("expected status %d, got %d: %s", http.StatusConflict, resp.Code, resp.Body.String())
-	}
-}
-
 // ── List ──────────────────────────────────────────────────────────────────────
 
 func TestAuthorAPIList(t *testing.T) {

--- a/internal/httpserver/books.go
+++ b/internal/httpserver/books.go
@@ -51,10 +51,5 @@ func writeCreateBookError(w http.ResponseWriter, err error) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if errors.Is(err, books.ErrTitleConflict) {
-		http.Error(w, err.Error(), http.StatusConflict)
-		return
-	}
-
 	http.Error(w, "failed to create book", http.StatusInternalServerError)
 }

--- a/internal/httpserver/books_test.go
+++ b/internal/httpserver/books_test.go
@@ -213,18 +213,6 @@ func TestBookAPICreateNormalizesBlankExtendedTextToNull(t *testing.T) {
 	testsupport.AssertBookRowFields(t, app.db, created.ID, testsupport.BookRowAssertion{Title: "Minimal"})
 }
 
-func TestBookAPICreateReturnsConflictForDuplicateTitle(t *testing.T) {
-	app := newTestApp(t)
-	testsupport.InsertBookRow(t, app.db, "Dune", nil)
-
-	req := httptest.NewRequest(http.MethodPost, "/api/books", bytes.NewBufferString(`{"title":"dUnE"}`))
-	resp := httptest.NewRecorder()
-	app.handler.ServeHTTP(resp, req)
-	if resp.Code != http.StatusConflict {
-		t.Fatalf("expected status %d, got %d: %s", http.StatusConflict, resp.Code, resp.Body.String())
-	}
-}
-
 func TestBookAPICreateRejectsInvalidDatesAndNumbers(t *testing.T) {
 	for _, body := range []string{
 		`{"title":"Bad Purchase","purchased_at":"2025-02-29"}`,


### PR DESCRIPTION
Support multiple owned copies of the same title and distinct authors who share a name.

- Remove title and author-name uniqueness checks from SQLite, services, repositories, and HTTP handlers
- Reject ambiguous CLI name references and require an explicit resource ID
- Cover duplicate creation and ambiguous references across database, service, HTTP, and CLI tests