### PR TITLE
Use integer IDs for persisted resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Bookist is intended to be a Go application for managing a home library.
 - Use SQLite for persistence with the pure-Go `modernc.org/sqlite` driver.
 - Use `github.com/pressly/goose/v3` for embedded SQL migrations. Serving runs migrations automatically at startup.
 - Keep Pico.css vendored as an embedded static asset rather than loading it from a CDN.
-- Every table, including relationship tables, uses a UUID `TEXT` primary key plus `created_at` and `updated_at` timestamps. ISBN remains nullable in Go and SQLite.
+- Every table, including relationship tables, uses an SQLite-generated `INTEGER PRIMARY KEY` represented as `int64` in Go, plus `created_at` and `updated_at` timestamps. ISBN remains nullable in Go and SQLite.
 - Collections default to `updated_at DESC, id ASC`; relationship-backed collections use the relationship row's timestamps and ID.
 - Enforce durable invariants in both services and SQLite constraints.
 - Rewriting the initial migration is acceptable while the schema is pre-release and disposable; once compatibility matters, migrations are append-only.

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module bakku.dev/bookist
 go 1.26.4
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/pressly/goose/v3 v3.27.1
 	modernc.org/sqlite v1.53.0
 )
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/internal/authors/author.go
+++ b/internal/authors/author.go
@@ -3,7 +3,7 @@ package authors
 import "time"
 
 type Author struct {
-	ID        string    `json:"id"`
+	ID        int64     `json:"id"`
 	Name      string    `json:"name"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`

--- a/internal/authors/service.go
+++ b/internal/authors/service.go
@@ -11,8 +11,8 @@ var ErrNameRequired = errors.New("name is required")
 type Repository interface {
 	Create(ctx context.Context, input CreateAuthorRequest) (Author, error)
 	List(ctx context.Context) ([]Author, error)
-	GetByIDs(ctx context.Context, ids []string) ([]Author, error)
-	ListByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error)
+	GetByIDs(ctx context.Context, ids []int64) ([]Author, error)
+	ListByBookIDs(ctx context.Context, bookIDs []int64) (map[int64][]Author, error)
 }
 
 type Service struct {
@@ -36,10 +36,10 @@ func (s *Service) List(ctx context.Context) ([]Author, error) {
 	return s.repository.List(ctx)
 }
 
-func (s *Service) GetByIDs(ctx context.Context, ids []string) ([]Author, error) {
+func (s *Service) GetByIDs(ctx context.Context, ids []int64) ([]Author, error) {
 	return s.repository.GetByIDs(ctx, ids)
 }
 
-func (s *Service) ListByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error) {
+func (s *Service) ListByBookIDs(ctx context.Context, bookIDs []int64) (map[int64][]Author, error) {
 	return s.repository.ListByBookIDs(ctx, bookIDs)
 }

--- a/internal/authors/sqlite_repository.go
+++ b/internal/authors/sqlite_repository.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type SQLiteRepository struct {
@@ -24,10 +22,10 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateAuthorRequest
 	updatedAt := createdAt
 
 	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO authors (id, name, created_at, updated_at)
-		VALUES (?, ?, ?, ?)
+		INSERT INTO authors (name, created_at, updated_at)
+		VALUES (?, ?, ?)
 		RETURNING id, name, created_at, updated_at
-	`, uuid.NewString(), input.Name, createdAt, updatedAt)
+	`, input.Name, createdAt, updatedAt)
 
 	return scanAuthor(row)
 }
@@ -58,7 +56,7 @@ func (r *SQLiteRepository) List(ctx context.Context) ([]Author, error) {
 	return authors, nil
 }
 
-func (r *SQLiteRepository) GetByIDs(ctx context.Context, ids []string) ([]Author, error) {
+func (r *SQLiteRepository) GetByIDs(ctx context.Context, ids []int64) ([]Author, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -97,9 +95,9 @@ func (r *SQLiteRepository) GetByIDs(ctx context.Context, ids []string) ([]Author
 	return authors, nil
 }
 
-func (r *SQLiteRepository) ListByBookIDs(ctx context.Context, bookIDs []string) (map[string][]Author, error) {
+func (r *SQLiteRepository) ListByBookIDs(ctx context.Context, bookIDs []int64) (map[int64][]Author, error) {
 	if len(bookIDs) == 0 {
-		return map[string][]Author{}, nil
+		return map[int64][]Author{}, nil
 	}
 
 	placeholders := make([]string, len(bookIDs))
@@ -123,9 +121,9 @@ func (r *SQLiteRepository) ListByBookIDs(ctx context.Context, bookIDs []string) 
 	}
 	defer rows.Close()
 
-	result := make(map[string][]Author)
+	result := make(map[int64][]Author)
 	for rows.Next() {
-		var bookID string
+		var bookID int64
 		var author Author
 		var name, createdAt, updatedAt string
 

--- a/internal/authors/sqlite_repository_test.go
+++ b/internal/authors/sqlite_repository_test.go
@@ -6,7 +6,6 @@ import (
 
 	"bakku.dev/bookist/internal/authors"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -20,11 +19,8 @@ func TestSQLiteRepositoryCreatePersistsAuthor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if created.ID == "" {
+	if created.ID <= 0 {
 		t.Fatal("expected created author to have an ID")
-	}
-	if _, err := uuid.Parse(created.ID); err != nil {
-		t.Fatalf("expected valid UUID, got %q: %v", created.ID, err)
 	}
 
 	testsupport.AssertAuthorRow(t, db, created.ID, "Jane Austen")
@@ -46,7 +42,7 @@ func TestSQLiteRepositoryListReadsPersistedAuthors(t *testing.T) {
 		t.Fatalf("expected 1 author, got %d", len(listed))
 	}
 	if listed[0].ID != id {
-		t.Fatalf("expected listed ID %s, got %s", id, listed[0].ID)
+		t.Fatalf("expected listed ID %d, got %d", id, listed[0].ID)
 	}
 	if listed[0].Name != "Jane Austen" {
 		t.Fatalf("expected Jane Austen, got %q", listed[0].Name)
@@ -76,7 +72,7 @@ func TestSQLiteRepositoryGetByIDsReturnsMatchingAuthors(t *testing.T) {
 	id1 := testsupport.InsertAuthorRow(t, db, "Author One")
 	id2 := testsupport.InsertAuthorRow(t, db, "Author Two")
 
-	found, err := repository.GetByIDs(ctx, []string{id1, id2, uuid.NewString()})
+	found, err := repository.GetByIDs(ctx, []int64{id1, id2, 999999})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +111,7 @@ func TestSQLiteRepositoryListByBookIDsReturnsAuthorsGroupedByBook(t *testing.T) 
 	testsupport.InsertBookAuthorRow(t, db, bookID1, authorID)
 	testsupport.InsertBookAuthorRow(t, db, bookID2, authorID)
 
-	result, err := repository.ListByBookIDs(ctx, []string{bookID1, bookID2})
+	result, err := repository.ListByBookIDs(ctx, []int64{bookID1, bookID2})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/books/book.go
+++ b/internal/books/book.go
@@ -23,7 +23,7 @@ const (
 )
 
 type Book struct {
-	ID                string           `json:"id"`
+	ID                int64            `json:"id"`
 	Title             string           `json:"title"`
 	ISBN              *string          `json:"isbn"`
 	Authors           []authors.Author `json:"authors"`
@@ -51,7 +51,7 @@ type Book struct {
 type CreateBookRequest struct {
 	Title             string     `json:"title"`
 	ISBN              *string    `json:"isbn"`
-	AuthorIDs         []string   `json:"author_ids"`
+	AuthorIDs         []int64    `json:"author_ids"`
 	Language          *string    `json:"language"`
 	Publisher         *string    `json:"publisher"`
 	Edition           *string    `json:"edition"`

--- a/internal/books/service.go
+++ b/internal/books/service.go
@@ -24,7 +24,7 @@ var ErrInvalidPublishedDay = errors.New("published_day must form a valid date an
 
 type Repository interface {
 	List(ctx context.Context) ([]Book, error)
-	ListByListID(ctx context.Context, listID string) ([]Book, error)
+	ListByListID(ctx context.Context, listID int64) ([]Book, error)
 	Create(ctx context.Context, input CreateBookRequest) (Book, error)
 }
 
@@ -47,7 +47,7 @@ func (s *Service) List(ctx context.Context) ([]Book, error) {
 		return books, nil
 	}
 
-	ids := make([]string, len(books))
+	ids := make([]int64, len(books))
 	for i, b := range books {
 		ids[i] = b.ID
 	}
@@ -68,7 +68,7 @@ func (s *Service) List(ctx context.Context) ([]Book, error) {
 	return books, nil
 }
 
-func (s *Service) ListByListID(ctx context.Context, listID string) ([]Book, error) {
+func (s *Service) ListByListID(ctx context.Context, listID int64) ([]Book, error) {
 	books, err := s.repository.ListByListID(ctx, listID)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s *Service) ListByListID(ctx context.Context, listID string) ([]Book, erro
 		return books, nil
 	}
 
-	ids := make([]string, len(books))
+	ids := make([]int64, len(books))
 	for i, b := range books {
 		ids[i] = b.ID
 	}
@@ -243,11 +243,13 @@ func (s *Service) Create(ctx context.Context, input CreateBookRequest) (Book, er
 		}
 	}
 
-	seen := make(map[string]bool)
-	var deduped []string
+	seen := make(map[int64]bool)
+	var deduped []int64
 	for _, id := range input.AuthorIDs {
-		id = strings.TrimSpace(id)
-		if id != "" && !seen[id] {
+		if id <= 0 {
+			return Book{}, ErrAuthorNotFound
+		}
+		if !seen[id] {
 			seen[id] = true
 			deduped = append(deduped, id)
 		}
@@ -262,7 +264,7 @@ func (s *Service) Create(ctx context.Context, input CreateBookRequest) (Book, er
 			return Book{}, err
 		}
 
-		foundMap := make(map[string]bool)
+		foundMap := make(map[int64]bool)
 		for _, a := range found {
 			foundMap[a.ID] = true
 		}

--- a/internal/books/service_test.go
+++ b/internal/books/service_test.go
@@ -8,7 +8,6 @@ import (
 
 	"bakku.dev/bookist/internal/books"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -42,7 +41,20 @@ func TestServiceCreateRejectsUnknownAuthorIDs(t *testing.T) {
 
 	_, err := service.Create(context.Background(), books.CreateBookRequest{
 		Title:     "Test",
-		AuthorIDs: []string{uuid.NewString()},
+		AuthorIDs: []int64{999999},
+	})
+	if !errors.Is(err, books.ErrAuthorNotFound) {
+		t.Fatalf("expected ErrAuthorNotFound, got %v", err)
+	}
+	testsupport.AssertBookCount(t, db, 0)
+}
+
+func TestServiceCreateRejectsNonPositiveAuthorIDs(t *testing.T) {
+	service, db := testsupport.NewBookService(t)
+
+	_, err := service.Create(context.Background(), books.CreateBookRequest{
+		Title:     "Test",
+		AuthorIDs: []int64{0},
 	})
 	if !errors.Is(err, books.ErrAuthorNotFound) {
 		t.Fatalf("expected ErrAuthorNotFound, got %v", err)
@@ -211,7 +223,7 @@ func TestServiceCreateWithValidAuthorIDsReturnsHydratedAuthors(t *testing.T) {
 	author := testsupport.InsertAuthorRow(t, db, "Test Author")
 	created, err := service.Create(context.Background(), books.CreateBookRequest{
 		Title:     "Test Book",
-		AuthorIDs: []string{author},
+		AuthorIDs: []int64{author},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -440,7 +452,7 @@ func TestServiceListReturnsPersistedBooks(t *testing.T) {
 	got := listed[0]
 
 	if got.ID != created.ID {
-		t.Fatalf("expected ID %s, got %s", created.ID, got.ID)
+		t.Fatalf("expected ID %d, got %d", created.ID, got.ID)
 	}
 
 	if got.Title != "Kindred" {

--- a/internal/books/sqlite_repository.go
+++ b/internal/books/sqlite_repository.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"bakku.dev/bookist/internal/authors"
-	"github.com/google/uuid"
 )
 
 type SQLiteRepository struct {
@@ -47,7 +46,7 @@ func (r *SQLiteRepository) List(ctx context.Context) ([]Book, error) {
 	return books, nil
 }
 
-func (r *SQLiteRepository) ListByListID(ctx context.Context, listID string) ([]Book, error) {
+func (r *SQLiteRepository) ListByListID(ctx context.Context, listID int64) ([]Book, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT b.id, b.title, b.isbn, b.language, b.publisher, b.edition, b.format,
 		       b.purchased_at, b.pages, b.notes, b.summary, b.series_name,
@@ -184,20 +183,18 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateBookRequest) 
 		publishedDay = sql.NullInt64{Int64: int64(*input.PublishedDay), Valid: true}
 	}
 
-	bookID := uuid.NewString()
-
 	row := tx.QueryRowContext(ctx, `
-		INSERT INTO books (id, title, isbn, language, publisher, edition, format, 
+		INSERT INTO books (title, isbn, language, publisher, edition, format,
 		                   purchased_at, pages, notes, summary, series_name,
 		                   series_position, location, condition, acquisition_source,
 		                   published_year, published_month, published_day,
 		                   created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		RETURNING id, title, isbn, language, publisher, edition, format, purchased_at, 
 			pages, notes, summary, series_name, series_position, location, condition,
 			acquisition_source, published_year, published_month, published_day,
 			created_at, updated_at
-	`, bookID, input.Title, isbn, language, publisher, edition, format, purchasedAt,
+	`, input.Title, isbn, language, publisher, edition, format, purchasedAt,
 		pages, notes, summary, seriesName, seriesPosition, location, condition,
 		acquisitionSource, publishedYear, publishedMonth, publishedDay, createdAt, updatedAt)
 
@@ -208,9 +205,9 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateBookRequest) 
 
 	for _, authorID := range input.AuthorIDs {
 		_, err := tx.ExecContext(ctx, `
-			INSERT INTO book_authors (id, book_id, author_id, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?)
-		`, uuid.NewString(), book.ID, authorID, createdAt, updatedAt)
+			INSERT INTO book_authors (book_id, author_id, created_at, updated_at)
+			VALUES (?, ?, ?, ?)
+		`, book.ID, authorID, createdAt, updatedAt)
 		if err != nil {
 			return Book{}, err
 		}

--- a/internal/books/sqlite_repository_test.go
+++ b/internal/books/sqlite_repository_test.go
@@ -57,7 +57,7 @@ func TestSQLiteRepositoryCreatePersistsAllFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if created.ID == "" {
+	if created.ID <= 0 {
 		t.Fatal("expected created book to have an ID")
 	}
 
@@ -109,7 +109,7 @@ func TestSQLiteRepositoryCreateWithAuthorIDsPersistsBookAuthors(t *testing.T) {
 
 	created, err := repository.Create(ctx, books.CreateBookRequest{
 		Title:     "Book With Authors",
-		AuthorIDs: []string{authorID},
+		AuthorIDs: []int64{authorID},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -193,7 +193,7 @@ func TestSQLiteRepositoryListReadsPersistedBooks(t *testing.T) {
 	got := listed[0]
 
 	if got.ID != created.ID {
-		t.Fatalf("expected ID %s, got %s", created.ID, got.ID)
+		t.Fatalf("expected ID %d, got %d", created.ID, got.ID)
 	}
 
 	if got.Title != "The Go Programming Language" {

--- a/internal/cli/authors.go
+++ b/internal/cli/authors.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"bakku.dev/bookist/internal/authors"
@@ -139,7 +140,7 @@ func runAuthorsList(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	rows := make([][]string, 0, len(listed))
 	for _, author := range listed {
-		rows = append(rows, []string{author.ID, author.Name})
+		rows = append(rows, []string{strconv.FormatInt(author.ID, 10), author.Name})
 	}
 
 	if err := writeListOutput(stdout, format, listed, []string{"ID", "NAME"}, rows); err != nil {
@@ -171,6 +172,6 @@ func runAuthorsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(stdout, "%s\t%s\n", author.ID, author.Name)
+	_, _ = fmt.Fprintf(stdout, "%d\t%s\n", author.ID, author.Name)
 	return 0
 }

--- a/internal/cli/authors_test.go
+++ b/internal/cli/authors_test.go
@@ -21,7 +21,7 @@ func TestAuthorsAddPrintsIDAndName(t *testing.T) {
 			json.NewDecoder(r.Body).Decode(&req)
 			capturedBody = req.Name
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(authors.Author{ID: "new-uuid", Name: req.Name})
+			json.NewEncoder(w).Encode(authors.Author{ID: 10, Name: req.Name})
 		}
 	}))
 	defer server.Close()
@@ -35,8 +35,8 @@ func TestAuthorsAddPrintsIDAndName(t *testing.T) {
 	if capturedBody != "Test Author" {
 		t.Fatalf("expected POST body name 'Test Author', got %q", capturedBody)
 	}
-	if !strings.Contains(stdout.String(), "new-uuid\tTest Author") {
-		t.Fatalf("expected stdout to contain 'new-uuid\\tTest Author', got %q", stdout.String())
+	if !strings.Contains(stdout.String(), "10\tTest Author") {
+		t.Fatalf("expected stdout to contain '10\\tTest Author', got %q", stdout.String())
 	}
 }
 
@@ -46,8 +46,8 @@ func TestAuthorsListTableFormats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/authors" {
 			_ = json.NewEncoder(w).Encode([]authors.Author{
-				{ID: "id-1", Name: "Author One"},
-				{ID: "id-2", Name: "Author Two"},
+				{ID: 1, Name: "Author One"},
+				{ID: 2, Name: "Author Two"},
 			})
 		}
 	}))
@@ -58,9 +58,9 @@ func TestAuthorsListTableFormats(t *testing.T) {
 		format   string
 		expected string
 	}{
-		{name: "default pretty", expected: "ID    NAME\nid-1  Author One\nid-2  Author Two\n"},
-		{name: "explicit TSV", format: "tsv", expected: "id-1\tAuthor One\nid-2\tAuthor Two\n"},
-		{name: "pretty", format: "pretty", expected: "ID    NAME\nid-1  Author One\nid-2  Author Two\n"},
+		{name: "default pretty", expected: "ID  NAME\n1   Author One\n2   Author Two\n"},
+		{name: "explicit TSV", format: "tsv", expected: "1\tAuthor One\n2\tAuthor Two\n"},
+		{name: "pretty", format: "pretty", expected: "ID  NAME\n1   Author One\n2   Author Two\n"},
 	}
 
 	for _, test := range tests {
@@ -86,7 +86,7 @@ func TestAuthorsListTableFormats(t *testing.T) {
 
 func TestAuthorsListJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode([]authors.Author{{ID: "id-1", Name: "Author One"}})
+		_ = json.NewEncoder(w).Encode([]authors.Author{{ID: 1, Name: "Author One"}})
 	}))
 	defer server.Close()
 
@@ -102,7 +102,7 @@ func TestAuthorsListJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &listed); err != nil {
 		t.Fatalf("expected valid JSON, got %q: %v", stdout, err)
 	}
-	if len(listed) != 1 || listed[0].ID != "id-1" || listed[0].Name != "Author One" {
+	if len(listed) != 1 || listed[0].ID != 1 || listed[0].Name != "Author One" {
 		t.Fatalf("expected complete author JSON, got %#v", listed)
 	}
 }

--- a/internal/cli/books.go
+++ b/internal/cli/books.go
@@ -8,12 +8,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
 	"bakku.dev/bookist/internal/authors"
 	"bakku.dev/bookist/internal/books"
-	"github.com/google/uuid"
 )
 
 func runBooks(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -88,7 +88,7 @@ func runBooksList(args []string, stdout io.Writer, stderr io.Writer) int {
 		if book.ISBN != nil {
 			isbn = *book.ISBN
 		}
-		rows = append(rows, []string{book.ID, book.Title, isbn})
+		rows = append(rows, []string{strconv.FormatInt(book.ID, 10), book.Title, isbn})
 	}
 
 	if err := writeListOutput(stdout, format, listedBooks, []string{"ID", "TITLE", "ISBN"}, rows); err != nil {
@@ -251,16 +251,16 @@ func runBooksAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(stdout, "%s\t%s\n", book.ID, book.Title)
+	_, _ = fmt.Fprintf(stdout, "%d\t%s\n", book.ID, book.Title)
 	return 0
 }
 
-func resolveAuthorIDs(serverURL string, values []string) ([]string, error) {
+func resolveAuthorIDs(serverURL string, values []string) ([]int64, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
 
-	var result []string
+	var result []int64
 	var byName map[string][]authors.Author
 
 	for _, val := range values {
@@ -269,10 +269,13 @@ func resolveAuthorIDs(serverURL string, values []string) ([]string, error) {
 			continue
 		}
 
-		parsed, err := uuid.Parse(val)
+		id, isID, err := parseIDReference(val)
+		if err != nil {
+			return nil, err
+		}
 
-		if err == nil && parsed.String() == strings.ToLower(val) {
-			result = append(result, parsed.String())
+		if isID {
+			result = append(result, id)
 		} else {
 			if byName == nil {
 				existingAuthors, err := fetchAuthors(serverURL)

--- a/internal/cli/books_test.go
+++ b/internal/cli/books_test.go
@@ -17,8 +17,8 @@ import (
 func TestBooksListTableFormats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode([]books.Book{
-			{ID: "id-1", Title: "Dune", ISBN: new("9780441172719")},
-			{ID: "id-2", Title: "Kindred", ISBN: nil},
+			{ID: 1, Title: "Dune", ISBN: new("9780441172719")},
+			{ID: 2, Title: "Kindred", ISBN: nil},
 		})
 	}))
 	defer server.Close()
@@ -28,9 +28,9 @@ func TestBooksListTableFormats(t *testing.T) {
 		format   string
 		expected string
 	}{
-		{name: "default pretty", expected: "ID    TITLE    ISBN\nid-1  Dune     9780441172719\nid-2  Kindred\n"},
-		{name: "explicit TSV", format: "tsv", expected: "id-1\tDune\t9780441172719\nid-2\tKindred\t\n"},
-		{name: "pretty", format: "pretty", expected: "ID    TITLE    ISBN\nid-1  Dune     9780441172719\nid-2  Kindred\n"},
+		{name: "default pretty", expected: "ID  TITLE    ISBN\n1   Dune     9780441172719\n2   Kindred\n"},
+		{name: "explicit TSV", format: "tsv", expected: "1\tDune\t9780441172719\n2\tKindred\t\n"},
+		{name: "pretty", format: "pretty", expected: "ID  TITLE    ISBN\n1   Dune     9780441172719\n2   Kindred\n"},
 	}
 
 	for _, test := range tests {
@@ -58,10 +58,10 @@ func TestBooksListJSONPreservesNullableFields(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode([]books.Book{
 			{
-				ID:                "id-1",
+				ID:                1,
 				Title:             "Dune",
 				ISBN:              new("9780441172719"),
-				Authors:           []authors.Author{{ID: "author-1", Name: "Frank Herbert"}},
+				Authors:           []authors.Author{{ID: 10, Name: "Frank Herbert"}},
 				Summary:           new("A desert epic"),
 				SeriesName:        new("Dune"),
 				SeriesPosition:    new(1.5),
@@ -69,7 +69,7 @@ func TestBooksListJSONPreservesNullableFields(t *testing.T) {
 				Condition:         new(books.ConditionVeryGood),
 				AcquisitionSource: new("Bookshop"),
 			},
-			{ID: "id-2", Title: "Kindred", ISBN: nil},
+			{ID: 2, Title: "Kindred", ISBN: nil},
 		})
 	}))
 	defer server.Close()
@@ -122,7 +122,7 @@ func TestBooksAddWithNewFields(t *testing.T) {
 			json.NewDecoder(r.Body).Decode(&req)
 			postedBooks = append(postedBooks, req)
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(books.Book{ID: "new-book-id", Title: req.Title})
+			json.NewEncoder(w).Encode(books.Book{ID: 10, Title: req.Title})
 		}
 	}))
 	defer server.Close()
@@ -221,7 +221,7 @@ func TestBooksAddSendsNullForOmittedOptionalFields(t *testing.T) {
 			t.Fatal(err)
 		}
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(books.Book{ID: "new-book-id", Title: posted.Title})
+		_ = json.NewEncoder(w).Encode(books.Book{ID: 10, Title: posted.Title})
 	}))
 	defer server.Close()
 
@@ -273,7 +273,7 @@ func TestBooksAddWithAuthorNameExistsLinksAuthor(t *testing.T) {
 			switch r.Method {
 			case http.MethodGet:
 				json.NewEncoder(w).Encode([]authors.Author{
-					{ID: "existing-id", Name: "Existing Author"},
+					{ID: 5, Name: "Existing Author"},
 				})
 
 			case http.MethodPost:
@@ -285,7 +285,7 @@ func TestBooksAddWithAuthorNameExistsLinksAuthor(t *testing.T) {
 			json.NewDecoder(r.Body).Decode(&req)
 			postedBooks = append(postedBooks, req)
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(books.Book{ID: "new-book-id", Title: req.Title})
+			json.NewEncoder(w).Encode(books.Book{ID: 10, Title: req.Title})
 		}
 	}))
 	defer server.Close()
@@ -299,8 +299,8 @@ func TestBooksAddWithAuthorNameExistsLinksAuthor(t *testing.T) {
 	if len(postedBooks) != 1 {
 		t.Fatalf("expected 1 POST /api/books, got %d", len(postedBooks))
 	}
-	if len(postedBooks[0].AuthorIDs) != 1 || postedBooks[0].AuthorIDs[0] != "existing-id" {
-		t.Fatalf("expected author_ids [existing-id], got %#v", postedBooks[0].AuthorIDs)
+	if len(postedBooks[0].AuthorIDs) != 1 || postedBooks[0].AuthorIDs[0] != 5 {
+		t.Fatalf("expected author_ids [5], got %#v", postedBooks[0].AuthorIDs)
 	}
 }
 
@@ -310,8 +310,8 @@ func TestBooksAddWithAmbiguousAuthorNameRequiresID(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/authors":
 			_ = json.NewEncoder(w).Encode([]authors.Author{
-				{ID: "author-1", Name: "Alex Smith"},
-				{ID: "author-2", Name: "alex SMITH"},
+				{ID: 1, Name: "Alex Smith"},
+				{ID: 2, Name: "alex SMITH"},
 			})
 		case "/api/books":
 			bookPosted = true
@@ -349,7 +349,7 @@ func TestBooksAddWithAuthorNameNotFoundCreatesAuthorThenBook(t *testing.T) {
 				json.NewDecoder(r.Body).Decode(&req)
 				postedAuthors = append(postedAuthors, req)
 				w.WriteHeader(http.StatusCreated)
-				json.NewEncoder(w).Encode(authors.Author{ID: "new-author-id", Name: req.Name})
+				json.NewEncoder(w).Encode(authors.Author{ID: 5, Name: req.Name})
 			}
 
 		case "/api/books":
@@ -357,7 +357,7 @@ func TestBooksAddWithAuthorNameNotFoundCreatesAuthorThenBook(t *testing.T) {
 			json.NewDecoder(r.Body).Decode(&req)
 			postedBooks = append(postedBooks, req)
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(books.Book{ID: "new-book-id", Title: req.Title})
+			json.NewEncoder(w).Encode(books.Book{ID: 10, Title: req.Title})
 		}
 	}))
 	defer server.Close()
@@ -374,36 +374,31 @@ func TestBooksAddWithAuthorNameNotFoundCreatesAuthorThenBook(t *testing.T) {
 	if len(postedBooks) != 1 {
 		t.Fatalf("expected 1 POST /api/books, got %d", len(postedBooks))
 	}
-	if len(postedBooks[0].AuthorIDs) != 1 || postedBooks[0].AuthorIDs[0] != "new-author-id" {
-		t.Fatalf("expected author_ids [new-author-id], got %#v", postedBooks[0].AuthorIDs)
+	if len(postedBooks[0].AuthorIDs) != 1 || postedBooks[0].AuthorIDs[0] != 5 {
+		t.Fatalf("expected author_ids [5], got %#v", postedBooks[0].AuthorIDs)
 	}
-	if !strings.Contains(stdout.String(), "new-book-id\tMy Book") {
-		t.Fatalf("expected stdout to contain 'new-book-id\\tMy Book', got %q", stdout.String())
+	if !strings.Contains(stdout.String(), "10\tMy Book") {
+		t.Fatalf("expected stdout to contain '10\\tMy Book', got %q", stdout.String())
 	}
 }
 
-func TestBooksAddWithAuthorUUIDExistsLinksAuthor(t *testing.T) {
+func TestBooksAddWithIntegerAuthorIDLinksAuthor(t *testing.T) {
 	var postedBooks []books.CreateBookRequest
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/authors":
-			json.NewEncoder(w).Encode([]authors.Author{
-				{ID: "550e8400-e29b-41d4-a716-446655440000", Name: "UUID Author"},
-			})
-
 		case "/api/books":
 			var req books.CreateBookRequest
 			json.NewDecoder(r.Body).Decode(&req)
 			postedBooks = append(postedBooks, req)
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(books.Book{ID: "new-book-id", Title: req.Title})
+			json.NewEncoder(w).Encode(books.Book{ID: 10, Title: req.Title})
 		}
 	}))
 	defer server.Close()
 
 	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"books", "add", "--title", "My Book", "--author", "550e8400-e29b-41d4-a716-446655440000", "--server", server.URL}, &stdout, &stderr)
+	exitCode := cli.Run([]string{"books", "add", "--title", "My Book", "--author", "5", "--server", server.URL}, &stdout, &stderr)
 
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
@@ -411,12 +406,12 @@ func TestBooksAddWithAuthorUUIDExistsLinksAuthor(t *testing.T) {
 	if len(postedBooks) != 1 {
 		t.Fatalf("expected 1 POST /api/books, got %d", len(postedBooks))
 	}
-	if len(postedBooks[0].AuthorIDs) != 1 || postedBooks[0].AuthorIDs[0] != "550e8400-e29b-41d4-a716-446655440000" {
-		t.Fatalf("expected author_ids [550e8400...], got %#v", postedBooks[0].AuthorIDs)
+	if len(postedBooks[0].AuthorIDs) != 1 || postedBooks[0].AuthorIDs[0] != 5 {
+		t.Fatalf("expected author_ids [5], got %#v", postedBooks[0].AuthorIDs)
 	}
 }
 
-func TestBooksAddPassesAuthorUUIDThroughWithoutLookup(t *testing.T) {
+func TestBooksAddPassesAuthorIntegerIDThroughWithoutLookup(t *testing.T) {
 	var posted books.CreateBookRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -426,18 +421,34 @@ func TestBooksAddPassesAuthorUUIDThroughWithoutLookup(t *testing.T) {
 		case "/api/books":
 			_ = json.NewDecoder(r.Body).Decode(&posted)
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(books.Book{ID: "book-id", Title: posted.Title})
+			_ = json.NewEncoder(w).Encode(books.Book{ID: 10, Title: posted.Title})
 		}
 	}))
 	defer server.Close()
 
 	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"books", "add", "--title", "My Book", "--author", "550e8400-e29b-41d4-a716-446655440000", "--server", server.URL}, &stdout, &stderr)
+	exitCode := cli.Run([]string{"books", "add", "--title", "My Book", "--author", "5", "--server", server.URL}, &stdout, &stderr)
 
 	if exitCode != 0 {
 		t.Fatalf("expected success, got %d: %s", exitCode, stderr.String())
 	}
-	if len(posted.AuthorIDs) != 1 || posted.AuthorIDs[0] != "550e8400-e29b-41d4-a716-446655440000" {
-		t.Fatalf("expected UUID to pass through, got %#v", posted.AuthorIDs)
+	if len(posted.AuthorIDs) != 1 || posted.AuthorIDs[0] != 5 {
+		t.Fatalf("expected integer ID to pass through, got %#v", posted.AuthorIDs)
+	}
+}
+
+func TestBooksAddRejectsInvalidAuthorIntegerIDs(t *testing.T) {
+	for _, id := range []string{"0", "999999999999999999999999"} {
+		t.Run(id, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			exitCode := cli.Run([]string{"books", "add", "--title", "My Book", "--author", id}, &stdout, &stderr)
+
+			if exitCode == 0 {
+				t.Fatal("expected non-zero exit code")
+			}
+			if !strings.Contains(stderr.String(), `invalid ID "`+id+`"`) {
+				t.Fatalf("unexpected error: %q", stderr.String())
+			}
+		})
 	}
 }

--- a/internal/cli/id.go
+++ b/internal/cli/id.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func parseIDReference(value string) (int64, bool, error) {
+	id, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		if id <= 0 {
+			return 0, true, fmt.Errorf("invalid ID %q", value)
+		}
+		return id, true, nil
+	}
+	if errors.Is(err, strconv.ErrRange) {
+		return 0, true, fmt.Errorf("invalid ID %q", value)
+	}
+	return 0, false, nil
+}

--- a/internal/cli/lists.go
+++ b/internal/cli/lists.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"bakku.dev/bookist/internal/lists"
-	"github.com/google/uuid"
 )
 
 func runLists(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -85,7 +85,7 @@ func runListsList(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	rows := make([][]string, 0, len(listed))
 	for _, list := range listed {
-		rows = append(rows, []string{list.ID, list.Name})
+		rows = append(rows, []string{strconv.FormatInt(list.ID, 10), list.Name})
 	}
 
 	if err := writeListOutput(stdout, format, listed, []string{"ID", "NAME"}, rows); err != nil {
@@ -154,7 +154,7 @@ func runListsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(stdout, "%s\t%s\n", created.ID, created.Name)
+	_, _ = fmt.Fprintf(stdout, "%d\t%s\n", created.ID, created.Name)
 	return 0
 }
 
@@ -196,7 +196,7 @@ func runListsAddBook(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	endpoint, err := joinURL(*serverURL, "/api/lists/"+listID+"/books")
+	endpoint, err := joinURL(*serverURL, "/api/lists/"+strconv.FormatInt(listID, 10)+"/books")
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "invalid server URL: %v\n", err)
 		return 2
@@ -225,24 +225,27 @@ func runListsAddBook(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(stdout, "added book %s to list %s\n", bookID, listID)
+	_, _ = fmt.Fprintf(stdout, "added book %d to list %d\n", bookID, listID)
 	return 0
 }
 
-func resolveListID(serverURL, value string) (string, error) {
+func resolveListID(serverURL, value string) (int64, error) {
 	value = strings.TrimSpace(value)
 
-	parsed, err := uuid.Parse(value)
-	if err == nil && parsed.String() == strings.ToLower(value) {
-		return parsed.String(), nil
+	id, isID, err := parseIDReference(value)
+	if err != nil {
+		return 0, err
+	}
+	if isID {
+		return id, nil
 	}
 
 	existing, err := fetchLists(serverURL)
 	if err != nil {
-		return "", fmt.Errorf("fetch lists: %v", err)
+		return 0, fmt.Errorf("fetch lists: %v", err)
 	}
 
-	byName := make(map[string]string)
+	byName := make(map[string]int64)
 	for _, l := range existing {
 		if _, exists := byName[strings.ToLower(l.Name)]; !exists {
 			byName[strings.ToLower(l.Name)] = l.ID
@@ -253,23 +256,26 @@ func resolveListID(serverURL, value string) (string, error) {
 		return id, nil
 	}
 
-	return "", fmt.Errorf("list not found: %s", value)
+	return 0, fmt.Errorf("list not found: %s", value)
 }
 
-func resolveBookID(serverURL, value string) (string, error) {
+func resolveBookID(serverURL, value string) (int64, error) {
 	value = strings.TrimSpace(value)
 
-	parsed, err := uuid.Parse(value)
-	if err == nil && parsed.String() == strings.ToLower(value) {
-		return parsed.String(), nil
+	id, isID, err := parseIDReference(value)
+	if err != nil {
+		return 0, err
+	}
+	if isID {
+		return id, nil
 	}
 
 	existing, err := fetchBooks(serverURL)
 	if err != nil {
-		return "", fmt.Errorf("fetch books: %v", err)
+		return 0, fmt.Errorf("fetch books: %v", err)
 	}
 
-	byTitle := make(map[string][]string)
+	byTitle := make(map[string][]int64)
 	for _, b := range existing {
 		key := strings.ToLower(b.Title)
 		byTitle[key] = append(byTitle[key], b.ID)
@@ -277,13 +283,13 @@ func resolveBookID(serverURL, value string) (string, error) {
 
 	matches := byTitle[strings.ToLower(value)]
 	if len(matches) > 1 {
-		return "", fmt.Errorf("book %q exists multiple times; pass a book ID instead", value)
+		return 0, fmt.Errorf("book %q exists multiple times; pass a book ID instead", value)
 	}
 	if len(matches) == 1 {
 		return matches[0], nil
 	}
 
-	return "", fmt.Errorf("book not found: %s", value)
+	return 0, fmt.Errorf("book not found: %s", value)
 }
 
 func fetchLists(serverURL string) ([]lists.List, error) {

--- a/internal/cli/lists_test.go
+++ b/internal/cli/lists_test.go
@@ -17,8 +17,8 @@ func TestListsListTableFormats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/api/lists" {
 			_ = json.NewEncoder(w).Encode([]lists.List{
-				{ID: "id-1", Name: "Want to Buy"},
-				{ID: "id-2", Name: "Nightstand"},
+				{ID: 1, Name: "Want to Buy"},
+				{ID: 2, Name: "Nightstand"},
 			})
 		}
 	}))
@@ -29,9 +29,9 @@ func TestListsListTableFormats(t *testing.T) {
 		format   string
 		expected string
 	}{
-		{name: "default pretty", expected: "ID    NAME\nid-1  Want to Buy\nid-2  Nightstand\n"},
-		{name: "explicit TSV", format: "tsv", expected: "id-1\tWant to Buy\nid-2\tNightstand\n"},
-		{name: "pretty", format: "pretty", expected: "ID    NAME\nid-1  Want to Buy\nid-2  Nightstand\n"},
+		{name: "default pretty", expected: "ID  NAME\n1   Want to Buy\n2   Nightstand\n"},
+		{name: "explicit TSV", format: "tsv", expected: "1\tWant to Buy\n2\tNightstand\n"},
+		{name: "pretty", format: "pretty", expected: "ID  NAME\n1   Want to Buy\n2   Nightstand\n"},
 	}
 
 	for _, test := range tests {
@@ -59,8 +59,8 @@ func TestListsListJSONPreservesNullableDescription(t *testing.T) {
 	description := "Books to purchase"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode([]lists.List{
-			{ID: "id-1", Name: "Want to Buy", Description: &description},
-			{ID: "id-2", Name: "Nightstand", Description: nil},
+			{ID: 1, Name: "Want to Buy", Description: &description},
+			{ID: 2, Name: "Nightstand", Description: nil},
 		})
 	}))
 	defer server.Close()
@@ -96,7 +96,7 @@ func TestListsAddPrintsIDAndName(t *testing.T) {
 		if r.Method == http.MethodPost && r.URL.Path == "/api/lists" {
 			json.NewDecoder(r.Body).Decode(&capturedBody)
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(lists.List{ID: "new-uuid", Name: capturedBody.Name})
+			json.NewEncoder(w).Encode(lists.List{ID: 10, Name: capturedBody.Name})
 		}
 	}))
 	defer server.Close()
@@ -110,8 +110,8 @@ func TestListsAddPrintsIDAndName(t *testing.T) {
 	if capturedBody.Name != "Want to Buy" {
 		t.Fatalf("expected POST body name 'Want to Buy', got %q", capturedBody.Name)
 	}
-	if !strings.Contains(stdout.String(), "new-uuid\tWant to Buy") {
-		t.Fatalf("expected stdout to contain 'new-uuid\\tWant to Buy', got %q", stdout.String())
+	if !strings.Contains(stdout.String(), "10\tWant to Buy") {
+		t.Fatalf("expected stdout to contain '10\\tWant to Buy', got %q", stdout.String())
 	}
 }
 
@@ -123,7 +123,7 @@ func TestListsAddBookResolvesListByName(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/lists":
 			json.NewEncoder(w).Encode([]lists.List{
-				{ID: "list-1", Name: "Want to Buy"},
+				{ID: 1, Name: "Want to Buy"},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/books":
 			json.NewEncoder(w).Encode([]interface{}{})
@@ -135,17 +135,17 @@ func TestListsAddBookResolvesListByName(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"lists", "add-book", "--list", "want TO buy", "--book", "550e8400-e29b-41d4-a716-446655440000", "--server", server.URL}, &stdout, &stderr)
+	exitCode := cli.Run([]string{"lists", "add-book", "--list", "want TO buy", "--book", "2", "--server", server.URL}, &stdout, &stderr)
 
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
 	}
-	if capturedPath != "/api/lists/list-1/books" {
-		t.Fatalf("expected POST to /api/lists/list-1/books, got %s", capturedPath)
+	if capturedPath != "/api/lists/1/books" {
+		t.Fatalf("expected POST to /api/lists/1/books, got %s", capturedPath)
 	}
 }
 
-func TestListsAddBookResolvesListByUUID(t *testing.T) {
+func TestListsAddBookPassesIntegerIDsThrough(t *testing.T) {
 	var capturedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -157,13 +157,13 @@ func TestListsAddBookResolvesListByUUID(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"lists", "add-book", "--list", "550e8400-e29b-41d4-a716-446655440000", "--book", "550e8400-e29b-41d4-a716-446655440001", "--server", server.URL}, &stdout, &stderr)
+	exitCode := cli.Run([]string{"lists", "add-book", "--list", "10", "--book", "20", "--server", server.URL}, &stdout, &stderr)
 
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
 	}
-	if capturedPath != "/api/lists/550e8400-e29b-41d4-a716-446655440000/books" {
-		t.Fatalf("expected POST to /api/lists/550e8400-e29b-41d4-a716-446655440000/books, got %s", capturedPath)
+	if capturedPath != "/api/lists/10/books" {
+		t.Fatalf("expected POST to /api/lists/10/books, got %s", capturedPath)
 	}
 }
 
@@ -173,14 +173,14 @@ func TestListsAddBookResolvesBookByTitle(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/lists":
 			json.NewEncoder(w).Encode([]lists.List{
-				{ID: "list-1", Name: "Want to Buy"},
+				{ID: 1, Name: "Want to Buy"},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/books":
 			json.NewEncoder(w).Encode([]struct {
-				ID    string `json:"id"`
+				ID    int64  `json:"id"`
 				Title string `json:"title"`
 			}{
-				{ID: "book-1", Title: "Dune"},
+				{ID: 2, Title: "Dune"},
 			})
 		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/lists/"):
 			json.NewDecoder(r.Body).Decode(&capturedBody)
@@ -195,8 +195,8 @@ func TestListsAddBookResolvesBookByTitle(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
 	}
-	if capturedBody.BookID != "book-1" {
-		t.Fatalf("expected book_id 'book-1', got %q", capturedBody.BookID)
+	if capturedBody.BookID != 2 {
+		t.Fatalf("expected book_id 2, got %d", capturedBody.BookID)
 	}
 }
 
@@ -205,14 +205,14 @@ func TestListsAddBookWithAmbiguousTitleRequiresID(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/lists":
-			_ = json.NewEncoder(w).Encode([]lists.List{{ID: "list-1", Name: "Want to Buy"}})
+			_ = json.NewEncoder(w).Encode([]lists.List{{ID: 1, Name: "Want to Buy"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/books":
 			_ = json.NewEncoder(w).Encode([]struct {
-				ID    string `json:"id"`
+				ID    int64  `json:"id"`
 				Title string `json:"title"`
 			}{
-				{ID: "book-1", Title: "Dune"},
-				{ID: "book-2", Title: "dUnE"},
+				{ID: 1, Title: "Dune"},
+				{ID: 2, Title: "dUnE"},
 			})
 		case r.Method == http.MethodPost:
 			bookPosted = true
@@ -243,7 +243,7 @@ func TestListsAddBookListNotFoundExitsNonZero(t *testing.T) {
 	defer server.Close()
 
 	var stdout, stderr strings.Builder
-	exitCode := cli.Run([]string{"lists", "add-book", "--list", "Nonexistent", "--book", "550e8400-e29b-41d4-a716-446655440000", "--server", server.URL}, &stdout, &stderr)
+	exitCode := cli.Run([]string{"lists", "add-book", "--list", "Nonexistent", "--book", "1", "--server", server.URL}, &stdout, &stderr)
 
 	if exitCode == 0 {
 		t.Fatalf("expected non-zero exit code, got 0")
@@ -258,11 +258,11 @@ func TestListsAddBookBookNotFoundExitsNonZero(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/lists":
 			json.NewEncoder(w).Encode([]lists.List{
-				{ID: "list-1", Name: "Want to Buy"},
+				{ID: 1, Name: "Want to Buy"},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/api/books":
 			json.NewEncoder(w).Encode([]struct {
-				ID    string `json:"id"`
+				ID    int64  `json:"id"`
 				Title string `json:"title"`
 			}{})
 		}

--- a/internal/cli/reads.go
+++ b/internal/cli/reads.go
@@ -93,7 +93,7 @@ func runReadsList(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	for _, read := range listed {
 		rows = append(rows, []string{
-			read.ID,
+			strconv.FormatInt(read.ID, 10),
 			stringValue(read.StartedAt),
 			stringValue(read.FinishedAt),
 			stringValue(read.AbandonedAt),
@@ -164,7 +164,7 @@ func runReadsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	endpoint, err := joinURL(*serverURL, "/api/books/"+bookID+"/reads")
+	endpoint, err := joinURL(*serverURL, "/api/books/"+strconv.FormatInt(bookID, 10)+"/reads")
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "invalid server URL: %v\n", err)
 		return 2
@@ -192,13 +192,13 @@ func runReadsAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(stdout, "%s\t%s\n", created.ID, created.BookID)
+	_, _ = fmt.Fprintf(stdout, "%d\t%d\n", created.ID, created.BookID)
 
 	return 0
 }
 
-func fetchReads(serverURL, bookID string) ([]reads.Read, error) {
-	endpoint, err := joinURL(serverURL, "/api/books/"+bookID+"/reads")
+func fetchReads(serverURL string, bookID int64) ([]reads.Read, error) {
+	endpoint, err := joinURL(serverURL, "/api/books/"+strconv.FormatInt(bookID, 10)+"/reads")
 	if err != nil {
 		return nil, fmt.Errorf("invalid server URL: %v", err)
 	}

--- a/internal/cli/reads_test.go
+++ b/internal/cli/reads_test.go
@@ -23,10 +23,10 @@ func TestReadsListResolvesBookAndPrintsTableFormats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/books":
-			_ = json.NewEncoder(w).Encode([]books.Book{{ID: "book-1", Title: "Dune"}})
-		case "/api/books/book-1/reads":
+			_ = json.NewEncoder(w).Encode([]books.Book{{ID: 1, Title: "Dune"}})
+		case "/api/books/1/reads":
 			_ = json.NewEncoder(w).Encode([]reads.Read{{
-				ID: "read-1", BookID: "book-1", StartedAt: &startedAt,
+				ID: 10, BookID: 1, StartedAt: &startedAt,
 				AbandonedAt: &abandonedAt, Rating: &rating, Notes: &notes,
 			}})
 		default:
@@ -41,9 +41,9 @@ func TestReadsListResolvesBookAndPrintsTableFormats(t *testing.T) {
 		format   string
 		expected string
 	}{
-		{name: "default pretty", expected: "ID      STARTED_AT  FINISHED_AT  ABANDONED_AT  RATING  NOTES\nread-1  2026-01-01               2026-01-03    4.5     Excellent\n"},
-		{name: "explicit TSV", format: "tsv", expected: "read-1\t2026-01-01\t\t2026-01-03\t4.5\tExcellent\n"},
-		{name: "pretty", format: "pretty", expected: "ID      STARTED_AT  FINISHED_AT  ABANDONED_AT  RATING  NOTES\nread-1  2026-01-01               2026-01-03    4.5     Excellent\n"},
+		{name: "default pretty", expected: "ID  STARTED_AT  FINISHED_AT  ABANDONED_AT  RATING  NOTES\n10  2026-01-01               2026-01-03    4.5     Excellent\n"},
+		{name: "explicit TSV", format: "tsv", expected: "10\t2026-01-01\t\t2026-01-03\t4.5\tExcellent\n"},
+		{name: "pretty", format: "pretty", expected: "ID  STARTED_AT  FINISHED_AT  ABANDONED_AT  RATING  NOTES\n10  2026-01-01               2026-01-03    4.5     Excellent\n"},
 	}
 
 	for _, test := range tests {
@@ -61,21 +61,21 @@ func TestReadsListResolvesBookAndPrintsTableFormats(t *testing.T) {
 }
 
 func TestReadsListJSONUsesFullReadRepresentation(t *testing.T) {
-	const bookID = "550e8400-e29b-41d4-a716-446655440000"
+	const bookID = int64(1)
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode([]reads.Read{{ID: "read-1", BookID: bookID, CreatedAt: now, UpdatedAt: now}})
+		_ = json.NewEncoder(w).Encode([]reads.Read{{ID: 10, BookID: bookID, CreatedAt: now, UpdatedAt: now}})
 	}))
 
 	defer server.Close()
 
-	exitCode, stdout, stderr := runCLI([]string{"reads", "list", "--book", bookID, "--server", server.URL, "--format", "json"})
+	exitCode, stdout, stderr := runCLI([]string{"reads", "list", "--book", "1", "--server", server.URL, "--format", "json"})
 
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("unexpected result: exit=%d stderr=%q", exitCode, stderr)
 	}
-	if !strings.Contains(stdout, `"started_at":null`) || !strings.Contains(stdout, `"abandoned_at":null`) || !strings.Contains(stdout, `"book_id":"`+bookID+`"`) ||
+	if !strings.Contains(stdout, `"started_at":null`) || !strings.Contains(stdout, `"abandoned_at":null`) || !strings.Contains(stdout, `"book_id":1`) ||
 		!strings.Contains(stdout, `"created_at":"2026-01-02T03:04:05Z"`) || !strings.Contains(stdout, `"updated_at":"2026-01-02T03:04:05Z"`) {
 		t.Fatalf("unexpected JSON output: %s", stdout)
 	}
@@ -84,7 +84,7 @@ func TestReadsListJSONUsesFullReadRepresentation(t *testing.T) {
 // ── Reads Add ─────────────────────────────────────────────────────────────────
 
 func TestReadsAddPostsToBookEndpoint(t *testing.T) {
-	const bookID = "550e8400-e29b-41d4-a716-446655440000"
+	const bookID = int64(1)
 	var captured reads.CreateReadRequest
 	var capturedPath string
 
@@ -94,13 +94,13 @@ func TestReadsAddPostsToBookEndpoint(t *testing.T) {
 			t.Error(err)
 		}
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(reads.Read{ID: "read-1", BookID: bookID})
+		_ = json.NewEncoder(w).Encode(reads.Read{ID: 10, BookID: bookID})
 	}))
 
 	defer server.Close()
 
 	exitCode, stdout, stderr := runCLI([]string{
-		"reads", "add", "--book", bookID, "--started-at", "2026-01-01",
+		"reads", "add", "--book", "1", "--started-at", "2026-01-01",
 		"--abandoned-at", "2026-01-03", "--rating", "4.5", "--notes", "Excellent",
 		"--server", server.URL,
 	})
@@ -108,13 +108,13 @@ func TestReadsAddPostsToBookEndpoint(t *testing.T) {
 	if exitCode != 0 || stderr != "" {
 		t.Fatalf("unexpected result: exit=%d stderr=%q", exitCode, stderr)
 	}
-	if capturedPath != "/api/books/"+bookID+"/reads" {
+	if capturedPath != "/api/books/1/reads" {
 		t.Fatalf("unexpected path %q", capturedPath)
 	}
 	if captured.StartedAt == nil || *captured.StartedAt != "2026-01-01" || captured.AbandonedAt == nil || *captured.AbandonedAt != "2026-01-03" || captured.Rating == nil || *captured.Rating != 4.5 {
 		t.Fatalf("unexpected request: %#v", captured)
 	}
-	if stdout != "read-1\t"+bookID+"\n" {
+	if stdout != "10\t1\n" {
 		t.Fatalf("unexpected stdout %q", stdout)
 	}
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -8,7 +8,6 @@ import (
 
 	"bakku.dev/bookist/internal/database"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 func TestOpenEnablesForeignKeysOnEveryConnection(t *testing.T) {
@@ -50,6 +49,7 @@ func TestInitialSchemaHasIDsAndTimestampsOnEveryTable(t *testing.T) {
 			defer rows.Close()
 
 			columns := make(map[string]struct {
+				kind    string
 				notNull bool
 				primary bool
 			})
@@ -62,12 +62,16 @@ func TestInitialSchemaHasIDsAndTimestampsOnEveryTable(t *testing.T) {
 					t.Fatal(err)
 				}
 				columns[name] = struct {
+					kind    string
 					notNull bool
 					primary bool
-				}{notNull: notNull == 1, primary: primary == 1}
+				}{kind: kind, notNull: notNull == 1, primary: primary == 1}
 			}
 			if !columns["id"].primary {
 				t.Fatal("expected id primary key")
+			}
+			if columns["id"].kind != "INTEGER" {
+				t.Fatalf("expected INTEGER id, got %q", columns["id"].kind)
 			}
 			if !columns["created_at"].notNull || !columns["updated_at"].notNull {
 				t.Fatal("expected non-null created_at and updated_at")
@@ -76,10 +80,11 @@ func TestInitialSchemaHasIDsAndTimestampsOnEveryTable(t *testing.T) {
 	}
 }
 
-func TestInitialSchemaRejectsNonUUIDIDs(t *testing.T) {
+func TestInitialSchemaGeneratesIntegerIDs(t *testing.T) {
 	db := testsupport.OpenMigratedDB(t)
-	if _, err := db.Exec(`INSERT INTO authors (id, name, created_at, updated_at) VALUES ('not-a-uuid', 'Jane Austen', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`); err == nil {
-		t.Fatal("expected non-UUID ID to violate a constraint")
+	id := testsupport.InsertAuthorRow(t, db, "Jane Austen")
+	if id <= 0 {
+		t.Fatalf("expected generated positive ID, got %d", id)
 	}
 }
 
@@ -101,10 +106,10 @@ func TestInitialSchemaEnforcesBookValidation(t *testing.T) {
 		for range test.args[1:] {
 			placeholders += ", ?"
 		}
-		args := []any{uuid.NewString(), test.title}
+		args := []any{test.title}
 		args = append(args, test.args...)
 		args = append(args, now, now)
-		query := `INSERT INTO books (id, title, ` + test.cols + `, created_at, updated_at) VALUES (?, ?, ` + placeholders + `, ?, ?)`
+		query := `INSERT INTO books (title, ` + test.cols + `, created_at, updated_at) VALUES (?, ` + placeholders + `, ?, ?)`
 		if _, err := db.Exec(query, args...); err == nil {
 			t.Fatalf("expected %s to violate a constraint", test.title)
 		}
@@ -130,9 +135,9 @@ func TestInitialSchemaSupportsExtendedBookMetadata(t *testing.T) {
 
 	for _, value := range []string{"new", "very_good", "good", "acceptable", "poor"} {
 		_, err := db.Exec(`
-			INSERT INTO books (id, title, summary, series_name, series_position, location, condition, acquisition_source, created_at, updated_at)
-			VALUES (?, ?, 'Summary', 'Series', 1.5, 'Shelf', ?, 'Gift', ?, ?)
-		`, uuid.NewString(), "Condition "+value, value, now, now)
+			INSERT INTO books (title, summary, series_name, series_position, location, condition, acquisition_source, created_at, updated_at)
+			VALUES (?, 'Summary', 'Series', 1.5, 'Shelf', ?, 'Gift', ?, ?)
+		`, "Condition "+value, value, now, now)
 		if err != nil {
 			t.Fatalf("expected condition %q and fractional position to be accepted: %v", value, err)
 		}
@@ -147,8 +152,8 @@ func TestInitialSchemaSupportsExtendedBookMetadata(t *testing.T) {
 		{title: "zero series position", column: "series_position", value: 0},
 		{title: "negative series position", column: "series_position", value: -1.5},
 	} {
-		query := `INSERT INTO books (id, title, ` + test.column + `, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-		if _, err := db.Exec(query, uuid.NewString(), test.title, test.value, now, now); err == nil {
+		query := `INSERT INTO books (title, ` + test.column + `, created_at, updated_at) VALUES (?, ?, ?, ?)`
+		if _, err := db.Exec(query, test.title, test.value, now, now); err == nil {
 			t.Fatalf("expected %s to violate a constraint", test.title)
 		}
 	}
@@ -163,10 +168,10 @@ func TestInitialSchemaEnforcesRelationshipMetadataAndUniqueness(t *testing.T) {
 	if _, err := db.Exec(`INSERT INTO book_authors (book_id, author_id) VALUES (?, ?)`, bookID, authorID); err == nil {
 		t.Fatal("expected relationship metadata to be required")
 	}
-	if _, err := db.Exec(`INSERT INTO book_authors (id, book_id, author_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`, uuid.NewString(), bookID, authorID, now, now); err != nil {
+	if _, err := db.Exec(`INSERT INTO book_authors (book_id, author_id, created_at, updated_at) VALUES (?, ?, ?, ?)`, bookID, authorID, now, now); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`INSERT INTO book_authors (id, book_id, author_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`, uuid.NewString(), bookID, authorID, now, now); err == nil {
+	if _, err := db.Exec(`INSERT INTO book_authors (book_id, author_id, created_at, updated_at) VALUES (?, ?, ?, ?)`, bookID, authorID, now, now); err == nil {
 		t.Fatal("expected relationship foreign-key pair to be unique")
 	}
 }

--- a/internal/database/migrations/00001_initial_tables.sql
+++ b/internal/database/migrations/00001_initial_tables.sql
@@ -1,11 +1,6 @@
 -- +goose Up
 CREATE TABLE books (
-    id TEXT PRIMARY KEY CHECK (
-        length(id) = 36 AND lower(id) = id AND
-        substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-' AND
-        substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
-        length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
-    ),
+    id INTEGER PRIMARY KEY,
     title TEXT NOT NULL COLLATE NOCASE CHECK (trim(title) <> ''),
     isbn TEXT NULL,
     language TEXT NULL,
@@ -50,62 +45,37 @@ CREATE TABLE books (
     updated_at TEXT NOT NULL
 );
 CREATE TABLE authors (
-    id TEXT PRIMARY KEY CHECK (
-        length(id) = 36 AND lower(id) = id AND
-        substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-' AND
-        substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
-        length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
-    ),
+    id INTEGER PRIMARY KEY,
     name TEXT NOT NULL COLLATE NOCASE CHECK (trim(name) <> ''),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
 CREATE TABLE book_authors (
-    id TEXT PRIMARY KEY CHECK (
-        length(id) = 36 AND lower(id) = id AND
-        substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-' AND
-        substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
-        length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
-    ),
-    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
-    author_id TEXT NOT NULL REFERENCES authors(id) ON DELETE CASCADE,
+    id INTEGER PRIMARY KEY,
+    book_id INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    author_id INTEGER NOT NULL REFERENCES authors(id) ON DELETE CASCADE,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     UNIQUE (book_id, author_id)
 );
 CREATE TABLE lists (
-    id TEXT PRIMARY KEY CHECK (
-        length(id) = 36 AND lower(id) = id AND
-        substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-' AND
-        substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
-        length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
-    ),
+    id INTEGER PRIMARY KEY,
     name TEXT NOT NULL COLLATE NOCASE UNIQUE CHECK (trim(name) <> ''),
     description TEXT NULL,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
 CREATE TABLE book_lists (
-    id TEXT PRIMARY KEY CHECK (
-        length(id) = 36 AND lower(id) = id AND
-        substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-' AND
-        substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
-        length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
-    ),
-    list_id TEXT NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
-    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    id INTEGER PRIMARY KEY,
+    list_id INTEGER NOT NULL REFERENCES lists(id) ON DELETE CASCADE,
+    book_id INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     UNIQUE (list_id, book_id)
 );
 CREATE TABLE reads (
-    id TEXT PRIMARY KEY CHECK (
-        length(id) = 36 AND lower(id) = id AND
-        substr(id, 9, 1) = '-' AND substr(id, 14, 1) = '-' AND
-        substr(id, 19, 1) = '-' AND substr(id, 24, 1) = '-' AND
-        length(replace(id, '-', '')) = 32 AND replace(id, '-', '') NOT GLOB '*[^0-9a-f]*'
-    ),
-    book_id TEXT NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    id INTEGER PRIMARY KEY,
+    book_id INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
     started_at TEXT NULL CHECK (
         started_at IS NULL OR (
             length(started_at) = 10 AND started_at GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]' AND

--- a/internal/httpserver/authors_test.go
+++ b/internal/httpserver/authors_test.go
@@ -30,7 +30,7 @@ func TestAuthorAPICreate(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
 		t.Fatal(err)
 	}
-	if created.ID == "" {
+	if created.ID <= 0 {
 		t.Fatal("expected created author to have an ID")
 	}
 	if created.Name != "Jane Austen" {

--- a/internal/httpserver/books_test.go
+++ b/internal/httpserver/books_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"bakku.dev/bookist/internal/books"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -52,7 +52,7 @@ func TestBookAPICreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if created.ID == "" {
+	if created.ID <= 0 {
 		t.Fatal("expected created book to have an ID")
 	}
 
@@ -125,7 +125,7 @@ func TestBookAPICreateRejectsFormBody(t *testing.T) {
 func TestBookAPICreateRejectsUnknownAuthor(t *testing.T) {
 	app := newTestApp(t)
 
-	body := bytes.NewBufferString(`{"title":"Test Book","author_ids":["` + uuid.NewString() + `"]}`)
+	body := bytes.NewBufferString(`{"title":"Test Book","author_ids":[999999]}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/books", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
@@ -143,7 +143,7 @@ func TestBookAPICreateWithAuthors(t *testing.T) {
 	app := newTestApp(t)
 	authorID := testsupport.InsertAuthorRow(t, app.db, "Test Author")
 
-	body := bytes.NewBufferString(`{"title":"Test Book","author_ids":["` + authorID + `"]}`)
+	body := bytes.NewBufferString(fmt.Sprintf(`{"title":"Test Book","author_ids":[%d]}`, authorID))
 	req := httptest.NewRequest(http.MethodPost, "/api/books", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
@@ -241,7 +241,7 @@ func TestBookAPIList(t *testing.T) {
 	app := newTestApp(t)
 	now := "2026-01-02T03:04:05Z"
 
-	id := uuid.NewString()
+	id := int64(100)
 	_, err := app.db.ExecContext(context.Background(), `
 		INSERT INTO books (id, title, isbn, language, publisher, edition, format,
 		                   purchased_at, pages, notes, summary, series_name,
@@ -274,7 +274,7 @@ func TestBookAPIList(t *testing.T) {
 	got := listed[0]
 
 	if got.ID != id {
-		t.Fatalf("expected ID %s, got %s", id, got.ID)
+		t.Fatalf("expected ID %d, got %d", id, got.ID)
 	}
 	if got.Title != "Dune" {
 		t.Fatalf("expected Dune, got %q", got.Title)

--- a/internal/httpserver/lists.go
+++ b/internal/httpserver/lists.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 
 	"bakku.dev/bookist/internal/lists"
 )
@@ -39,9 +38,13 @@ func (s *Server) handleAPICreateList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAPIListBooksInList(w http.ResponseWriter, r *http.Request) {
-	listID := r.PathValue("id")
+	listID, err := parseID(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, "invalid list ID", http.StatusBadRequest)
+		return
+	}
 
-	_, err := s.lists.GetByID(r.Context(), listID)
+	_, err = s.lists.GetByID(r.Context(), listID)
 	if err != nil {
 		if errors.Is(err, lists.ErrListNotFound) {
 			http.Error(w, "list not found", http.StatusNotFound)
@@ -61,7 +64,11 @@ func (s *Server) handleAPIListBooksInList(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleAPIAddBookToList(w http.ResponseWriter, r *http.Request) {
-	listID := r.PathValue("id")
+	listID, err := parseID(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, "invalid list ID", http.StatusBadRequest)
+		return
+	}
 
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
@@ -72,12 +79,12 @@ func (s *Server) handleAPIAddBookToList(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if strings.TrimSpace(input.BookID) == "" {
+	if input.BookID <= 0 {
 		http.Error(w, "book_id is required", http.StatusBadRequest)
 		return
 	}
 
-	err := s.lists.AddBookToList(r.Context(), listID, input.BookID)
+	err = s.lists.AddBookToList(r.Context(), listID, input.BookID)
 	if err != nil {
 		writeAddBookToListError(w, err)
 		return

--- a/internal/httpserver/lists_test.go
+++ b/internal/httpserver/lists_test.go
@@ -3,6 +3,7 @@ package httpserver_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"bakku.dev/bookist/internal/books"
 	"bakku.dev/bookist/internal/lists"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -32,7 +32,7 @@ func TestListAPICreate(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
 		t.Fatal(err)
 	}
-	if created.ID == "" {
+	if created.ID <= 0 {
 		t.Fatal("expected created list to have an ID")
 	}
 	if created.Name != "Want to Buy" {
@@ -126,8 +126,8 @@ func TestListAPIAddBookToList(t *testing.T) {
 	listID := testsupport.InsertListRow(t, app.db, "Want to Buy")
 	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
 
-	body := bytes.NewBufferString(`{"book_id":"` + bookID + `"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/lists/"+listID+"/books", body)
+	body := bytes.NewBufferString(fmt.Sprintf(`{"book_id":%d}`, bookID))
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/lists/%d/books", listID), body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 
@@ -143,10 +143,10 @@ func TestListAPIAddBookToListRejectsUnknownBook(t *testing.T) {
 	app := newTestApp(t)
 
 	listID := testsupport.InsertListRow(t, app.db, "Want to Buy")
-	unknownBookID := uuid.NewString()
+	unknownBookID := int64(999999)
 
-	body := bytes.NewBufferString(`{"book_id":"` + unknownBookID + `"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/lists/"+listID+"/books", body)
+	body := bytes.NewBufferString(fmt.Sprintf(`{"book_id":%d}`, unknownBookID))
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/lists/%d/books", listID), body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 
@@ -160,10 +160,10 @@ func TestListAPIAddBookToListReturns404ForUnknownList(t *testing.T) {
 	app := newTestApp(t)
 
 	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
-	unknownListID := uuid.NewString()
+	unknownListID := int64(999999)
 
-	body := bytes.NewBufferString(`{"book_id":"` + bookID + `"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/lists/"+unknownListID+"/books", body)
+	body := bytes.NewBufferString(fmt.Sprintf(`{"book_id":%d}`, bookID))
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/lists/%d/books", unknownListID), body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 
@@ -179,8 +179,8 @@ func TestListAPIAddBookToListReturns409ForDuplicate(t *testing.T) {
 	listID := testsupport.InsertListRow(t, app.db, "Want to Buy")
 	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
 
-	body := bytes.NewBufferString(`{"book_id":"` + bookID + `"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/lists/"+listID+"/books", body)
+	body := bytes.NewBufferString(fmt.Sprintf(`{"book_id":%d}`, bookID))
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/lists/%d/books", listID), body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 
@@ -189,14 +189,28 @@ func TestListAPIAddBookToListReturns409ForDuplicate(t *testing.T) {
 		t.Fatalf("expected first request to succeed, got %d", resp.Code)
 	}
 
-	body = bytes.NewBufferString(`{"book_id":"` + bookID + `"}`)
-	req = httptest.NewRequest(http.MethodPost, "/api/lists/"+listID+"/books", body)
+	body = bytes.NewBufferString(fmt.Sprintf(`{"book_id":%d}`, bookID))
+	req = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/lists/%d/books", listID), body)
 	req.Header.Set("Content-Type", "application/json")
 	resp = httptest.NewRecorder()
 
 	app.handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusConflict {
 		t.Fatalf("expected status %d for duplicate, got %d: %s", http.StatusConflict, resp.Code, resp.Body.String())
+	}
+}
+
+func TestListAPIAddBookToListRejectsInvalidIDs(t *testing.T) {
+	for _, path := range []string{"/api/lists/not-a-number/books", "/api/lists/0/books", "/api/lists/-1/books"} {
+		t.Run(path, func(t *testing.T) {
+			app := newTestApp(t)
+			req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{"book_id":1}`))
+			resp := httptest.NewRecorder()
+			app.handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, resp.Code, resp.Body.String())
+			}
+		})
 	}
 }
 
@@ -215,7 +229,7 @@ func TestListAPIListBooks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/lists/"+listID+"/books", nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/lists/%d/books", listID), nil)
 	resp := httptest.NewRecorder()
 	app.handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusOK {
@@ -242,7 +256,7 @@ func TestListAPIListBooksReturnsEmptyArrayForEmptyList(t *testing.T) {
 
 	listID := testsupport.InsertListRow(t, app.db, "Want to Buy")
 
-	req := httptest.NewRequest(http.MethodGet, "/api/lists/"+listID+"/books", nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/lists/%d/books", listID), nil)
 	resp := httptest.NewRecorder()
 	app.handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusOK {
@@ -264,9 +278,9 @@ func TestListAPIListBooksReturnsEmptyArrayForEmptyList(t *testing.T) {
 func TestListAPIListBooksReturns404ForUnknownList(t *testing.T) {
 	app := newTestApp(t)
 
-	unknownListID := uuid.NewString()
+	unknownListID := int64(999999)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/lists/"+unknownListID+"/books", nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/lists/%d/books", unknownListID), nil)
 	resp := httptest.NewRecorder()
 	app.handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusNotFound {
@@ -283,7 +297,7 @@ func TestListAPIListBooksHydratesAuthors(t *testing.T) {
 	testsupport.InsertBookAuthorRow(t, app.db, bookID, authorID)
 	testsupport.InsertBookListRow(t, app.db, listID, bookID)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/lists/"+listID+"/books", nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/lists/%d/books", listID), nil)
 	resp := httptest.NewRecorder()
 	app.handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusOK {

--- a/internal/httpserver/reads.go
+++ b/internal/httpserver/reads.go
@@ -9,7 +9,13 @@ import (
 )
 
 func (s *Server) handleAPIListReads(w http.ResponseWriter, r *http.Request) {
-	result, err := s.reads.ListByBookID(r.Context(), r.PathValue("id"))
+	bookID, err := parseID(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, "invalid book ID", http.StatusBadRequest)
+		return
+	}
+
+	result, err := s.reads.ListByBookID(r.Context(), bookID)
 	if err != nil {
 		if errors.Is(err, reads.ErrBookNotFound) {
 			http.Error(w, err.Error(), http.StatusNotFound)
@@ -24,6 +30,12 @@ func (s *Server) handleAPIListReads(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAPICreateRead(w http.ResponseWriter, r *http.Request) {
+	bookID, err := parseID(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, "invalid book ID", http.StatusBadRequest)
+		return
+	}
+
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 
@@ -33,7 +45,7 @@ func (s *Server) handleAPICreateRead(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := s.reads.Create(r.Context(), r.PathValue("id"), input)
+	result, err := s.reads.Create(r.Context(), bookID, input)
 	if err != nil {
 		writeCreateReadError(w, err)
 		return

--- a/internal/httpserver/reads_test.go
+++ b/internal/httpserver/reads_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -25,7 +25,7 @@ func TestReadAPICreate(t *testing.T) {
 		"notes":"Excellent"
 	}`)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/books/"+bookID+"/reads", body)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/books/%d/reads", bookID), body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
 
@@ -38,7 +38,7 @@ func TestReadAPICreate(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		t.Fatal(err)
 	}
-	if response["book_id"] != bookID || response["abandoned_at"] != "2026-01-03" || response["rating"] != 4.5 || response["notes"] != "Excellent" {
+	if response["book_id"] != float64(bookID) || response["abandoned_at"] != "2026-01-03" || response["rating"] != 4.5 || response["notes"] != "Excellent" {
 		t.Fatalf("unexpected response: %#v", response)
 	}
 	if response["created_at"] == nil {
@@ -72,7 +72,7 @@ func TestReadAPICreateRejectsClientTimestamp(t *testing.T) {
 	app := newTestApp(t)
 	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
 	body := bytes.NewBufferString(`{"created_at":"2026-01-01T00:00:00Z"}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/books/"+bookID+"/reads", body)
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/books/%d/reads", bookID), body)
 	resp := httptest.NewRecorder()
 
 	app.handler.ServeHTTP(resp, req)
@@ -83,12 +83,26 @@ func TestReadAPICreateRejectsClientTimestamp(t *testing.T) {
 
 func TestReadAPICreateReturns404ForUnknownBook(t *testing.T) {
 	app := newTestApp(t)
-	req := httptest.NewRequest(http.MethodPost, "/api/books/"+uuid.NewString()+"/reads", bytes.NewBufferString(`{}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/books/999999/reads", bytes.NewBufferString(`{}`))
 	resp := httptest.NewRecorder()
 
 	app.handler.ServeHTTP(resp, req)
 	if resp.Code != http.StatusNotFound {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusNotFound, resp.Code, resp.Body.String())
+	}
+}
+
+func TestReadAPIRejectsInvalidBookID(t *testing.T) {
+	for _, path := range []string{"/api/books/not-a-number/reads", "/api/books/0/reads", "/api/books/-1/reads"} {
+		t.Run(path, func(t *testing.T) {
+			app := newTestApp(t)
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			resp := httptest.NewRecorder()
+			app.handler.ServeHTTP(resp, req)
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, resp.Code, resp.Body.String())
+			}
+		})
 	}
 }
 
@@ -107,7 +121,7 @@ func TestReadAPICreateRejectsInvalidValues(t *testing.T) {
 		t.Run(body, func(t *testing.T) {
 			app := newTestApp(t)
 			bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
-			req := httptest.NewRequest(http.MethodPost, "/api/books/"+bookID+"/reads", bytes.NewBufferString(body))
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/books/%d/reads", bookID), bytes.NewBufferString(body))
 			resp := httptest.NewRecorder()
 
 			app.handler.ServeHTTP(resp, req)
@@ -130,8 +144,8 @@ func TestReadAPICreateRejectsInvalidValues(t *testing.T) {
 func TestReadAPIList(t *testing.T) {
 	app := newTestApp(t)
 	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
-	olderID := uuid.NewString()
-	newerID := uuid.NewString()
+	olderID := int64(100)
+	newerID := int64(101)
 	testsupport.InsertReadRow(t, app.db, testsupport.ReadRow{
 		ID: olderID, BookID: bookID, StartedAt: new("2025-01-01"), FinishedAt: new("2025-01-03"),
 		Rating: new(4.0), Notes: new("Good"), CreatedAt: "2026-01-01T00:00:00Z",
@@ -140,7 +154,7 @@ func TestReadAPIList(t *testing.T) {
 		ID: newerID, BookID: bookID, StartedAt: new("2026-01-01"), AbandonedAt: new("2026-01-03"),
 		Rating: new(4.5), Notes: new("Excellent"), CreatedAt: "2026-01-02T00:00:00Z",
 	})
-	req := httptest.NewRequest(http.MethodGet, "/api/books/"+bookID+"/reads", nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/books/%d/reads", bookID), nil)
 	resp := httptest.NewRecorder()
 
 	app.handler.ServeHTTP(resp, req)
@@ -152,7 +166,7 @@ func TestReadAPIList(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		t.Fatal(err)
 	}
-	if len(raw) != 2 || raw[0]["id"] != newerID || raw[1]["id"] != olderID {
+	if len(raw) != 2 || raw[0]["id"] != float64(newerID) || raw[1]["id"] != float64(olderID) {
 		t.Fatalf("expected newest reads first, got %#v", raw)
 	}
 	if raw[0]["abandoned_at"] != "2026-01-03" || raw[0]["finished_at"] != nil || raw[1]["abandoned_at"] != nil {
@@ -170,7 +184,7 @@ func TestReadAPIList(t *testing.T) {
 func TestReadAPIListReturnsEmptyArray(t *testing.T) {
 	app := newTestApp(t)
 	bookID := testsupport.InsertBookRow(t, app.db, "Dune", nil)
-	req := httptest.NewRequest(http.MethodGet, "/api/books/"+bookID+"/reads", nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/books/%d/reads", bookID), nil)
 	resp := httptest.NewRecorder()
 
 	app.handler.ServeHTTP(resp, req)
@@ -181,7 +195,7 @@ func TestReadAPIListReturnsEmptyArray(t *testing.T) {
 
 func TestReadAPIListReturns404ForUnknownBook(t *testing.T) {
 	app := newTestApp(t)
-	req := httptest.NewRequest(http.MethodGet, "/api/books/"+uuid.NewString()+"/reads", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/books/999999/reads", nil)
 	resp := httptest.NewRecorder()
 
 	app.handler.ServeHTTP(resp, req)

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -1,8 +1,10 @@
 package httpserver
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
+	"strconv"
 
 	"bakku.dev/bookist/internal/authors"
 	"bakku.dev/bookist/internal/books"
@@ -17,6 +19,14 @@ type Server struct {
 	lists     *lists.Service
 	reads     *reads.Service
 	templates *template.Template
+}
+
+func parseID(value string) (int64, error) {
+	id, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("invalid ID")
+	}
+	return id, nil
 }
 
 func New(books *books.Service, authors *authors.Service, lists *lists.Service, reads *reads.Service) (*Server, error) {

--- a/internal/lists/list.go
+++ b/internal/lists/list.go
@@ -3,7 +3,7 @@ package lists
 import "time"
 
 type List struct {
-	ID          string    `json:"id"`
+	ID          int64     `json:"id"`
 	Name        string    `json:"name"`
 	Description *string   `json:"description"`
 	CreatedAt   time.Time `json:"created_at"`
@@ -16,5 +16,5 @@ type CreateListRequest struct {
 }
 
 type AddBookToListRequest struct {
-	BookID string `json:"book_id"`
+	BookID int64 `json:"book_id"`
 }

--- a/internal/lists/service.go
+++ b/internal/lists/service.go
@@ -16,8 +16,8 @@ type Repository interface {
 	Create(ctx context.Context, input CreateListRequest) (List, error)
 	List(ctx context.Context) ([]List, error)
 	NameExists(ctx context.Context, name string) (bool, error)
-	GetByID(ctx context.Context, id string) (List, error)
-	AddBookToList(ctx context.Context, listID, bookID string) error
+	GetByID(ctx context.Context, id int64) (List, error)
+	AddBookToList(ctx context.Context, listID, bookID int64) error
 }
 
 type Service struct {
@@ -57,10 +57,10 @@ func (s *Service) List(ctx context.Context) ([]List, error) {
 	return s.repository.List(ctx)
 }
 
-func (s *Service) GetByID(ctx context.Context, id string) (List, error) {
+func (s *Service) GetByID(ctx context.Context, id int64) (List, error) {
 	return s.repository.GetByID(ctx, id)
 }
 
-func (s *Service) AddBookToList(ctx context.Context, listID, bookID string) error {
+func (s *Service) AddBookToList(ctx context.Context, listID, bookID int64) error {
 	return s.repository.AddBookToList(ctx, listID, bookID)
 }

--- a/internal/lists/sqlite_repository.go
+++ b/internal/lists/sqlite_repository.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type SQLiteRepository struct {
@@ -29,10 +27,10 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateListRequest) 
 	}
 
 	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO lists (id, name, description, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
+		INSERT INTO lists (name, description, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
 		RETURNING id, name, description, created_at, updated_at
-	`, uuid.NewString(), input.Name, description, createdAt, updatedAt)
+	`, input.Name, description, createdAt, updatedAt)
 
 	list, err := scanList(row)
 	if err != nil && isUniqueViolation(err) {
@@ -78,7 +76,7 @@ func (r *SQLiteRepository) List(ctx context.Context) ([]List, error) {
 	return lists, nil
 }
 
-func (r *SQLiteRepository) GetByID(ctx context.Context, id string) (List, error) {
+func (r *SQLiteRepository) GetByID(ctx context.Context, id int64) (List, error) {
 	row := r.db.QueryRowContext(ctx, `
 		SELECT id, name, description, created_at, updated_at
 		FROM lists
@@ -96,12 +94,12 @@ func (r *SQLiteRepository) GetByID(ctx context.Context, id string) (List, error)
 	return list, nil
 }
 
-func (r *SQLiteRepository) AddBookToList(ctx context.Context, listID, bookID string) error {
+func (r *SQLiteRepository) AddBookToList(ctx context.Context, listID, bookID int64) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := r.db.ExecContext(ctx, `
-		INSERT INTO book_lists (id, list_id, book_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, uuid.NewString(), listID, bookID, now, now)
+		INSERT INTO book_lists (list_id, book_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+	`, listID, bookID, now, now)
 
 	if err != nil {
 		if isFKViolation(err) {

--- a/internal/lists/sqlite_repository_test.go
+++ b/internal/lists/sqlite_repository_test.go
@@ -7,7 +7,6 @@ import (
 
 	"bakku.dev/bookist/internal/lists"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -21,11 +20,8 @@ func TestSQLiteRepositoryCreatePersistsList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if created.ID == "" {
+	if created.ID <= 0 {
 		t.Fatal("expected created list to have an ID")
-	}
-	if _, err := uuid.Parse(created.ID); err != nil {
-		t.Fatalf("expected valid UUID, got %q: %v", created.ID, err)
 	}
 
 	testsupport.AssertListRow(t, db, created.ID, "Want to Buy")
@@ -81,7 +77,7 @@ func TestSQLiteRepositoryListReadsPersistedLists(t *testing.T) {
 		wantFirst, wantSecond = id2, id1
 	}
 	if listed[0].ID != wantFirst || listed[1].ID != wantSecond {
-		t.Fatalf("expected ID tie-break ordering [%s %s], got [%s %s]", wantFirst, wantSecond, listed[0].ID, listed[1].ID)
+		t.Fatalf("expected ID tie-break ordering [%d %d], got [%d %d]", wantFirst, wantSecond, listed[0].ID, listed[1].ID)
 	}
 }
 
@@ -98,7 +94,7 @@ func TestSQLiteRepositoryGetByIDReturnsList(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got.ID != id {
-		t.Fatalf("expected ID %s, got %s", id, got.ID)
+		t.Fatalf("expected ID %d, got %d", id, got.ID)
 	}
 	if got.Name != "Want to Buy" {
 		t.Fatalf("expected Want to Buy, got %q", got.Name)
@@ -110,7 +106,7 @@ func TestSQLiteRepositoryGetByIDReturnsErrListNotFound(t *testing.T) {
 	db := testsupport.OpenMigratedDB(t)
 	repository := lists.NewSQLiteRepository(db)
 
-	_, err := repository.GetByID(ctx, uuid.NewString())
+	_, err := repository.GetByID(ctx, 999999)
 	if !errors.Is(err, lists.ErrListNotFound) {
 		t.Fatalf("expected ErrListNotFound, got %v", err)
 	}
@@ -160,7 +156,7 @@ func TestSQLiteRepositoryAddBookToListReturnsErrListNotFound(t *testing.T) {
 
 	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
 
-	err := repository.AddBookToList(ctx, uuid.NewString(), bookID)
+	err := repository.AddBookToList(ctx, 999999, bookID)
 	if !errors.Is(err, lists.ErrListNotFound) {
 		t.Fatalf("expected ErrListNotFound, got %v", err)
 	}
@@ -173,7 +169,7 @@ func TestSQLiteRepositoryAddBookToListReturnsErrBookNotFound(t *testing.T) {
 
 	listID := testsupport.InsertListRow(t, db, "Want to Buy")
 
-	err := repository.AddBookToList(ctx, listID, uuid.NewString())
+	err := repository.AddBookToList(ctx, listID, 999999)
 	if !errors.Is(err, lists.ErrBookNotFound) {
 		t.Fatalf("expected ErrBookNotFound, got %v", err)
 	}

--- a/internal/reads/read.go
+++ b/internal/reads/read.go
@@ -3,8 +3,8 @@ package reads
 import "time"
 
 type Read struct {
-	ID          string    `json:"id"`
-	BookID      string    `json:"book_id"`
+	ID          int64     `json:"id"`
+	BookID      int64     `json:"book_id"`
 	StartedAt   *string   `json:"started_at"`
 	FinishedAt  *string   `json:"finished_at"`
 	AbandonedAt *string   `json:"abandoned_at"`

--- a/internal/reads/service.go
+++ b/internal/reads/service.go
@@ -19,8 +19,8 @@ var ErrAbandonedBeforeStarted = errors.New("abandoned_at must not be before star
 var ErrInvalidRating = errors.New("rating must be between 1 and 5 in increments of 0.5")
 
 type Repository interface {
-	Create(ctx context.Context, bookID string, input CreateReadRequest) (Read, error)
-	ListByBookID(ctx context.Context, bookID string) ([]Read, error)
+	Create(ctx context.Context, bookID int64, input CreateReadRequest) (Read, error)
+	ListByBookID(ctx context.Context, bookID int64) ([]Read, error)
 }
 
 type Service struct {
@@ -31,7 +31,7 @@ func NewService(repository Repository) *Service {
 	return &Service{repository: repository}
 }
 
-func (s *Service) Create(ctx context.Context, bookID string, input CreateReadRequest) (Read, error) {
+func (s *Service) Create(ctx context.Context, bookID int64, input CreateReadRequest) (Read, error) {
 	startedAt, err := normalizeDate(input.StartedAt, ErrInvalidStartedAt)
 	if err != nil {
 		return Read{}, err
@@ -80,7 +80,7 @@ func (s *Service) Create(ctx context.Context, bookID string, input CreateReadReq
 	return s.repository.Create(ctx, bookID, input)
 }
 
-func (s *Service) ListByBookID(ctx context.Context, bookID string) ([]Read, error) {
+func (s *Service) ListByBookID(ctx context.Context, bookID int64) ([]Read, error) {
 	return s.repository.ListByBookID(ctx, bookID)
 }
 

--- a/internal/reads/service_test.go
+++ b/internal/reads/service_test.go
@@ -7,7 +7,6 @@ import (
 
 	"bakku.dev/bookist/internal/reads"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -118,7 +117,7 @@ func TestServiceCreatePermitsAbandonedReadWithoutStart(t *testing.T) {
 func TestServiceListByBookIDReturnsReads(t *testing.T) {
 	db := testsupport.OpenMigratedDB(t)
 	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
-	readID := uuid.NewString()
+	readID := int64(100)
 	testsupport.InsertReadRow(t, db, testsupport.ReadRow{
 		ID: readID, BookID: bookID, StartedAt: new("2026-01-01"),
 		AbandonedAt: new("2026-01-03"), Rating: new(4.5), Notes: new("Excellent"),

--- a/internal/reads/sqlite_repository.go
+++ b/internal/reads/sqlite_repository.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type SQLiteRepository struct {
@@ -19,16 +17,16 @@ func NewSQLiteRepository(db *sql.DB) *SQLiteRepository {
 	return &SQLiteRepository{db: db}
 }
 
-func (r *SQLiteRepository) Create(ctx context.Context, bookID string, input CreateReadRequest) (Read, error) {
+func (r *SQLiteRepository) Create(ctx context.Context, bookID int64, input CreateReadRequest) (Read, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	row := r.db.QueryRowContext(ctx, `
 		INSERT INTO reads (
-			id, book_id, started_at, finished_at, abandoned_at, rating, notes, created_at, updated_at
+			book_id, started_at, finished_at, abandoned_at, rating, notes, created_at, updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		RETURNING id, book_id, started_at, finished_at, abandoned_at, rating, notes, created_at, updated_at
-	`, uuid.NewString(), bookID, nullString(input.StartedAt), nullString(input.FinishedAt),
+	`, bookID, nullString(input.StartedAt), nullString(input.FinishedAt),
 		nullString(input.AbandonedAt), nullFloat64(input.Rating), nullString(input.Notes), now, now)
 
 	read, err := scanRead(row)
@@ -42,7 +40,7 @@ func (r *SQLiteRepository) Create(ctx context.Context, bookID string, input Crea
 	return read, nil
 }
 
-func (r *SQLiteRepository) ListByBookID(ctx context.Context, bookID string) ([]Read, error) {
+func (r *SQLiteRepository) ListByBookID(ctx context.Context, bookID int64) ([]Read, error) {
 	var exists int
 	if err := r.db.QueryRowContext(ctx, `SELECT 1 FROM books WHERE id = ?`, bookID).Scan(&exists); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/reads/sqlite_repository_test.go
+++ b/internal/reads/sqlite_repository_test.go
@@ -9,7 +9,6 @@ import (
 
 	"bakku.dev/bookist/internal/reads"
 	"bakku.dev/bookist/internal/testsupport"
-	"github.com/google/uuid"
 )
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -29,14 +28,14 @@ func TestSQLiteRepositoryCreatePersistsRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := uuid.Parse(created.ID); err != nil {
-		t.Fatalf("expected UUID read ID, got %q", created.ID)
+	if created.ID <= 0 {
+		t.Fatalf("expected positive read ID, got %d", created.ID)
 	}
 	if created.CreatedAt.IsZero() || created.UpdatedAt.IsZero() {
 		t.Fatal("expected backend timestamps")
 	}
 
-	var gotBookID string
+	var gotBookID int64
 	var gotStartedAt, gotFinishedAt, gotAbandonedAt, gotNotes sql.NullString
 	var gotRating sql.NullFloat64
 	var createdAt, updatedAt string
@@ -62,7 +61,7 @@ func TestSQLiteRepositoryCreateReturnsBookNotFound(t *testing.T) {
 	db := testsupport.OpenMigratedDB(t)
 	repository := reads.NewSQLiteRepository(db)
 
-	_, err := repository.Create(context.Background(), uuid.NewString(), reads.CreateReadRequest{})
+	_, err := repository.Create(context.Background(), 999999, reads.CreateReadRequest{})
 	if !errors.Is(err, reads.ErrBookNotFound) {
 		t.Fatalf("expected ErrBookNotFound, got %v", err)
 	}
@@ -74,8 +73,8 @@ func TestSQLiteRepositoryListByBookIDOrdersNewestFirst(t *testing.T) {
 	db := testsupport.OpenMigratedDB(t)
 	bookID := testsupport.InsertBookRow(t, db, "Dune", nil)
 	otherBookID := testsupport.InsertBookRow(t, db, "Foundation", nil)
-	oldID := uuid.NewString()
-	newID := uuid.NewString()
+	oldID := int64(100)
+	newID := int64(101)
 	testsupport.InsertReadRow(t, db, testsupport.ReadRow{
 		ID: oldID, BookID: bookID, StartedAt: new("2025-01-01"), FinishedAt: new("2025-01-02"),
 		CreatedAt: "2026-01-01T00:00:00Z",
@@ -85,7 +84,7 @@ func TestSQLiteRepositoryListByBookIDOrdersNewestFirst(t *testing.T) {
 		CreatedAt: "2026-01-02T00:00:00Z",
 	})
 	testsupport.InsertReadRow(t, db, testsupport.ReadRow{
-		ID: uuid.NewString(), BookID: otherBookID, StartedAt: new("2027-01-01"), FinishedAt: new("2027-01-02"),
+		ID: 102, BookID: otherBookID, StartedAt: new("2027-01-01"), FinishedAt: new("2027-01-02"),
 		CreatedAt: "2027-01-02T00:00:00Z",
 	})
 
@@ -117,7 +116,7 @@ func TestSQLiteRepositoryListByBookIDReturnsEmptySlice(t *testing.T) {
 func TestSQLiteRepositoryListByBookIDReturnsBookNotFound(t *testing.T) {
 	db := testsupport.OpenMigratedDB(t)
 
-	_, err := reads.NewSQLiteRepository(db).ListByBookID(context.Background(), uuid.NewString())
+	_, err := reads.NewSQLiteRepository(db).ListByBookID(context.Background(), 999999)
 	if !errors.Is(err, reads.ErrBookNotFound) {
 		t.Fatalf("expected ErrBookNotFound, got %v", err)
 	}
@@ -148,9 +147,9 @@ func TestReadsTableEnforcesRatingAndDateConstraints(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := db.Exec(`
-				INSERT INTO reads (id, book_id, started_at, finished_at, abandoned_at, rating, created_at, updated_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-			`, uuid.NewString(), bookID, test.startedAt, test.finishedAt, test.abandonedAt, test.rating, now, now)
+				INSERT INTO reads (book_id, started_at, finished_at, abandoned_at, rating, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+			`, bookID, test.startedAt, test.finishedAt, test.abandonedAt, test.rating, now, now)
 			if err == nil {
 				t.Fatal("expected database constraint error")
 			}
@@ -175,9 +174,9 @@ func TestReadsTablePermitsPartialAndSameDayTerminalDates(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := db.Exec(`
-				INSERT INTO reads (id, book_id, started_at, finished_at, abandoned_at, created_at, updated_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?)
-			`, uuid.NewString(), bookID, test.startedAt, test.finishedAt, test.abandonedAt, now, now)
+				INSERT INTO reads (book_id, started_at, finished_at, abandoned_at, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?)
+			`, bookID, test.startedAt, test.finishedAt, test.abandonedAt, now, now)
 			if err != nil {
 				t.Fatalf("expected valid read: %v", err)
 			}

--- a/internal/testsupport/authors.go
+++ b/internal/testsupport/authors.go
@@ -5,19 +5,18 @@ import (
 	"database/sql"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
 )
 
-func InsertAuthorRow(t testing.TB, db *sql.DB, name string) string {
+func InsertAuthorRow(t testing.TB, db *sql.DB, name string) int64 {
 	t.Helper()
 
 	now := "2026-01-02T03:04:05Z"
-	id := uuid.NewString()
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO authors (id, name, created_at, updated_at)
-		VALUES (?, ?, ?, ?)
-	`, id, name, now, now)
+	var id int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO authors (name, created_at, updated_at)
+		VALUES (?, ?, ?)
+		RETURNING id
+	`, name, now, now).Scan(&id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +24,7 @@ func InsertAuthorRow(t testing.TB, db *sql.DB, name string) string {
 	return id
 }
 
-func AssertAuthorRow(t testing.TB, db *sql.DB, id string, wantName string) {
+func AssertAuthorRow(t testing.TB, db *sql.DB, id int64, wantName string) {
 	t.Helper()
 
 	var name string

--- a/internal/testsupport/books.go
+++ b/internal/testsupport/books.go
@@ -8,7 +8,6 @@ import (
 
 	"bakku.dev/bookist/internal/authors"
 	"bakku.dev/bookist/internal/books"
-	"github.com/google/uuid"
 )
 
 func NewBookService(t testing.TB) (*books.Service, *sql.DB) {
@@ -19,7 +18,7 @@ func NewBookService(t testing.TB) (*books.Service, *sql.DB) {
 	return books.NewService(books.NewSQLiteRepository(db), authorRepo), db
 }
 
-func InsertBookRow(t testing.TB, db *sql.DB, title string, isbn *string) string {
+func InsertBookRow(t testing.TB, db *sql.DB, title string, isbn *string) int64 {
 	t.Helper()
 
 	now := "2026-01-02T03:04:05Z"
@@ -28,11 +27,12 @@ func InsertBookRow(t testing.TB, db *sql.DB, title string, isbn *string) string 
 		isbnValue = sql.NullString{String: *isbn, Valid: true}
 	}
 
-	id := uuid.NewString()
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO books (id, title, isbn, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, id, title, isbnValue, now, now)
+	var id int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO books (title, isbn, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+		RETURNING id
+	`, title, isbnValue, now, now).Scan(&id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ type BookRowAssertion struct {
 	PublishedDay      *int
 }
 
-func AssertBookRow(t testing.TB, db *sql.DB, id string, wantTitle string, wantISBN *string) {
+func AssertBookRow(t testing.TB, db *sql.DB, id int64, wantTitle string, wantISBN *string) {
 	t.Helper()
 
 	var title string
@@ -94,7 +94,7 @@ func AssertBookRow(t testing.TB, db *sql.DB, id string, wantTitle string, wantIS
 	}
 }
 
-func AssertBookRowFields(t testing.TB, db *sql.DB, id string, want BookRowAssertion) {
+func AssertBookRowFields(t testing.TB, db *sql.DB, id int64, want BookRowAssertion) {
 	t.Helper()
 
 	var title string
@@ -212,20 +212,20 @@ func AssertBookCount(t testing.TB, db *sql.DB, want int) {
 	}
 }
 
-func InsertBookAuthorRow(t testing.TB, db *sql.DB, bookID string, authorID string) {
+func InsertBookAuthorRow(t testing.TB, db *sql.DB, bookID int64, authorID int64) {
 	t.Helper()
 	now := "2026-01-02T03:04:05Z"
 
 	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO book_authors (id, book_id, author_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, uuid.NewString(), bookID, authorID, now, now)
+		INSERT INTO book_authors (book_id, author_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+	`, bookID, authorID, now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func AssertBookAuthors(t testing.TB, db *sql.DB, bookID string, wantAuthorIDs ...string) {
+func AssertBookAuthors(t testing.TB, db *sql.DB, bookID int64, wantAuthorIDs ...int64) {
 	t.Helper()
 
 	rows, err := db.QueryContext(context.Background(), `
@@ -238,9 +238,9 @@ func AssertBookAuthors(t testing.TB, db *sql.DB, bookID string, wantAuthorIDs ..
 	}
 	defer rows.Close()
 
-	var gotIDs []string
+	var gotIDs []int64
 	for rows.Next() {
-		var id string
+		var id int64
 		if err := rows.Scan(&id); err != nil {
 			t.Fatal(err)
 		}
@@ -253,16 +253,16 @@ func AssertBookAuthors(t testing.TB, db *sql.DB, bookID string, wantAuthorIDs ..
 	if len(gotIDs) != len(wantAuthorIDs) {
 		t.Fatalf("expected %d book_authors rows, got %d", len(wantAuthorIDs), len(gotIDs))
 	}
-	gotSet := make(map[string]bool, len(gotIDs))
+	gotSet := make(map[int64]bool, len(gotIDs))
 	for _, id := range gotIDs {
 		if gotSet[id] {
-			t.Fatalf("duplicate author_id %q in book_authors", id)
+			t.Fatalf("duplicate author_id %d in book_authors", id)
 		}
 		gotSet[id] = true
 	}
 	for _, want := range wantAuthorIDs {
 		if !gotSet[want] {
-			t.Fatalf("expected author_id %q not found in book_authors", want)
+			t.Fatalf("expected author_id %d not found in book_authors", want)
 		}
 	}
 }

--- a/internal/testsupport/lists.go
+++ b/internal/testsupport/lists.go
@@ -5,19 +5,35 @@ import (
 	"database/sql"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
 )
 
-func InsertListRow(t testing.TB, db *sql.DB, name string) string {
+func InsertListRow(t testing.TB, db *sql.DB, name string) int64 {
 	t.Helper()
 
 	now := "2026-01-02T03:04:05Z"
-	id := uuid.NewString()
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO lists (id, name, created_at, updated_at)
+	var id int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO lists (name, created_at, updated_at)
+		VALUES (?, ?, ?)
+		RETURNING id
+	`, name, now, now).Scan(&id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return id
+}
+
+func InsertListRowWithDescription(t testing.TB, db *sql.DB, name string, description string) int64 {
+	t.Helper()
+
+	now := "2026-01-02T03:04:05Z"
+	var id int64
+	err := db.QueryRowContext(context.Background(), `
+		INSERT INTO lists (name, description, created_at, updated_at)
 		VALUES (?, ?, ?, ?)
-	`, id, name, now, now)
+		RETURNING id
+	`, name, description, now, now).Scan(&id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,23 +41,7 @@ func InsertListRow(t testing.TB, db *sql.DB, name string) string {
 	return id
 }
 
-func InsertListRowWithDescription(t testing.TB, db *sql.DB, name string, description string) string {
-	t.Helper()
-
-	now := "2026-01-02T03:04:05Z"
-	id := uuid.NewString()
-	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO lists (id, name, description, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, id, name, description, now, now)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return id
-}
-
-func AssertListRow(t testing.TB, db *sql.DB, id string, wantName string) {
+func AssertListRow(t testing.TB, db *sql.DB, id int64, wantName string) {
 	t.Helper()
 
 	var name string
@@ -81,20 +81,20 @@ func AssertListCount(t testing.TB, db *sql.DB, want int) {
 	}
 }
 
-func InsertBookListRow(t testing.TB, db *sql.DB, listID string, bookID string) {
+func InsertBookListRow(t testing.TB, db *sql.DB, listID int64, bookID int64) {
 	t.Helper()
 	now := "2026-01-02T03:04:05Z"
 
 	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO book_lists (id, list_id, book_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
-	`, uuid.NewString(), listID, bookID, now, now)
+		INSERT INTO book_lists (list_id, book_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?)
+	`, listID, bookID, now, now)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func AssertBookListRow(t testing.TB, db *sql.DB, listID string, bookID string) {
+func AssertBookListRow(t testing.TB, db *sql.DB, listID int64, bookID int64) {
 	t.Helper()
 
 	var count int
@@ -105,11 +105,11 @@ func AssertBookListRow(t testing.TB, db *sql.DB, listID string, bookID string) {
 		t.Fatal(err)
 	}
 	if count != 1 {
-		t.Fatalf("expected 1 book_lists row for list %s book %s, got %d", listID, bookID, count)
+		t.Fatalf("expected 1 book_lists row for list %d book %d, got %d", listID, bookID, count)
 	}
 }
 
-func AssertBookListCount(t testing.TB, db *sql.DB, listID string, want int) {
+func AssertBookListCount(t testing.TB, db *sql.DB, listID int64, want int) {
 	t.Helper()
 
 	var count int
@@ -120,6 +120,6 @@ func AssertBookListCount(t testing.TB, db *sql.DB, listID string, want int) {
 		t.Fatal(err)
 	}
 	if count != want {
-		t.Fatalf("expected %d book_lists rows for list %s, got %d", want, listID, count)
+		t.Fatalf("expected %d book_lists rows for list %d, got %d", want, listID, count)
 	}
 }

--- a/internal/testsupport/reads.go
+++ b/internal/testsupport/reads.go
@@ -7,8 +7,8 @@ import (
 )
 
 type ReadRow struct {
-	ID          string
-	BookID      string
+	ID          int64
+	BookID      int64
 	StartedAt   *string
 	FinishedAt  *string
 	AbandonedAt *string


### PR DESCRIPTION
Replace UUID text keys with SQLite-generated integer primary keys and represent resource IDs as int64 throughout the application.

- Parse and validate positive numeric IDs at HTTP and CLI boundaries
- Let SQLite generate entity and relationship IDs
- Update API contracts, repositories, fixtures, and tests for numeric IDs