### PR TITLE
Add free-form purchase prices to books

### DIFF
--- a/internal/books/book.go
+++ b/internal/books/book.go
@@ -32,6 +32,7 @@ type Book struct {
 	Edition           *string          `json:"edition"`
 	Format            *Format          `json:"format"`
 	PurchasedAt       *string          `json:"purchased_at"`
+	PurchasePrice     *string          `json:"purchase_price"`
 	Pages             *int             `json:"pages"`
 	Notes             *string          `json:"notes"`
 	Summary           *string          `json:"summary"`
@@ -57,6 +58,7 @@ type CreateBookRequest struct {
 	Edition           *string    `json:"edition"`
 	Format            *Format    `json:"format"`
 	PurchasedAt       *string    `json:"purchased_at"`
+	PurchasePrice     *string    `json:"purchase_price"`
 	Pages             *int       `json:"pages"`
 	Notes             *string    `json:"notes"`
 	Summary           *string    `json:"summary"`

--- a/internal/books/service.go
+++ b/internal/books/service.go
@@ -164,6 +164,15 @@ func (s *Service) Create(ctx context.Context, input CreateBookRequest) (Book, er
 		}
 	}
 
+	if input.PurchasePrice != nil {
+		v := strings.TrimSpace(*input.PurchasePrice)
+		if v == "" {
+			input.PurchasePrice = nil
+		} else {
+			input.PurchasePrice = &v
+		}
+	}
+
 	if input.Notes != nil {
 		v := strings.TrimSpace(*input.Notes)
 		if v == "" {

--- a/internal/books/service_test.go
+++ b/internal/books/service_test.go
@@ -70,6 +70,7 @@ func TestServiceCreateTrimsAndPersistsInput(t *testing.T) {
 	ed := " 2nd "
 	format := books.FormatPaperback
 	purchased := " 2025-06-15 "
+	purchasePrice := " 12.34 EUR "
 	pages := 400
 	notes := " Great "
 	summary := " A practical Go guide "
@@ -90,6 +91,7 @@ func TestServiceCreateTrimsAndPersistsInput(t *testing.T) {
 		Edition:           &ed,
 		Format:            &format,
 		PurchasedAt:       &purchased,
+		PurchasePrice:     &purchasePrice,
 		Pages:             &pages,
 		Notes:             &notes,
 		Summary:           &summary,
@@ -132,6 +134,10 @@ func TestServiceCreateTrimsAndPersistsInput(t *testing.T) {
 
 	if created.PurchasedAt == nil || *created.PurchasedAt != "2025-06-15" {
 		t.Fatalf("expected trimmed PurchasedAt '2025-06-15', got %#v", created.PurchasedAt)
+	}
+
+	if created.PurchasePrice == nil || *created.PurchasePrice != "12.34 EUR" {
+		t.Fatalf("expected trimmed PurchasePrice '12.34 EUR', got %#v", created.PurchasePrice)
 	}
 
 	if created.Pages == nil || *created.Pages != 400 {
@@ -188,6 +194,7 @@ func TestServiceCreateTrimsAndPersistsInput(t *testing.T) {
 		Edition:           new("2nd"),
 		Format:            &f,
 		PurchasedAt:       new("2025-06-15"),
+		PurchasePrice:     new("12.34 EUR"),
 		Pages:             new(400),
 		Notes:             new("Great"),
 		Summary:           new("A practical Go guide"),
@@ -284,6 +291,7 @@ func TestServiceCreateConvertsBlankStringFieldsToNull(t *testing.T) {
 	location := " "
 	acquisitionSource := " "
 	purchased := " "
+	purchasePrice := " "
 
 	created, err := service.Create(context.Background(), books.CreateBookRequest{
 		Title:             "Blank Fields",
@@ -296,6 +304,7 @@ func TestServiceCreateConvertsBlankStringFieldsToNull(t *testing.T) {
 		Location:          &location,
 		AcquisitionSource: &acquisitionSource,
 		PurchasedAt:       &purchased,
+		PurchasePrice:     &purchasePrice,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/books/sqlite_repository.go
+++ b/internal/books/sqlite_repository.go
@@ -20,7 +20,7 @@ func NewSQLiteRepository(db *sql.DB) *SQLiteRepository {
 func (r *SQLiteRepository) List(ctx context.Context) ([]Book, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, title, isbn, language, publisher, edition, format, 
-		    purchased_at, pages, notes, summary, series_name, series_position,
+		    purchased_at, purchase_price, pages, notes, summary, series_name, series_position,
 		    location, condition, acquisition_source, published_year,
 		    published_month, published_day, created_at, updated_at
 		FROM books
@@ -49,7 +49,7 @@ func (r *SQLiteRepository) List(ctx context.Context) ([]Book, error) {
 func (r *SQLiteRepository) ListByListID(ctx context.Context, listID int64) ([]Book, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT b.id, b.title, b.isbn, b.language, b.publisher, b.edition, b.format,
-		       b.purchased_at, b.pages, b.notes, b.summary, b.series_name,
+		       b.purchased_at, b.purchase_price, b.pages, b.notes, b.summary, b.series_name,
 		       b.series_position, b.location, b.condition, b.acquisition_source,
 		       b.published_year, b.published_month, b.published_day,
 		       b.created_at, b.updated_at
@@ -128,6 +128,11 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateBookRequest) 
 		purchasedAt = sql.NullString{String: *input.PurchasedAt, Valid: true}
 	}
 
+	purchasePrice := sql.NullString{}
+	if input.PurchasePrice != nil {
+		purchasePrice = sql.NullString{String: *input.PurchasePrice, Valid: true}
+	}
+
 	notes := sql.NullString{}
 	if input.Notes != nil {
 		notes = sql.NullString{String: *input.Notes, Valid: true}
@@ -185,16 +190,17 @@ func (r *SQLiteRepository) Create(ctx context.Context, input CreateBookRequest) 
 
 	row := tx.QueryRowContext(ctx, `
 		INSERT INTO books (title, isbn, language, publisher, edition, format,
-		                   purchased_at, pages, notes, summary, series_name,
+		                   purchased_at, purchase_price, pages, notes, summary, series_name,
 		                   series_position, location, condition, acquisition_source,
 		                   published_year, published_month, published_day,
 		                   created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		RETURNING id, title, isbn, language, publisher, edition, format, purchased_at, 
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING id, title, isbn, language, publisher, edition, format, purchased_at,
+			purchase_price,
 			pages, notes, summary, series_name, series_position, location, condition,
 			acquisition_source, published_year, published_month, published_day,
 			created_at, updated_at
-	`, input.Title, isbn, language, publisher, edition, format, purchasedAt,
+	`, input.Title, isbn, language, publisher, edition, format, purchasedAt, purchasePrice,
 		pages, notes, summary, seriesName, seriesPosition, location, condition,
 		acquisitionSource, publishedYear, publishedMonth, publishedDay, createdAt, updatedAt)
 
@@ -234,6 +240,7 @@ func scanBook(scanner bookScanner) (Book, error) {
 	var edition sql.NullString
 	var format sql.NullString
 	var purchasedAt sql.NullString
+	var purchasePrice sql.NullString
 	var pages sql.NullInt64
 	var notes sql.NullString
 	var summary sql.NullString
@@ -249,7 +256,7 @@ func scanBook(scanner bookScanner) (Book, error) {
 	var updatedAt string
 
 	if err := scanner.Scan(&book.ID, &book.Title, &isbn, &language, &publisher, &edition,
-		&format, &purchasedAt, &pages, &notes, &summary, &seriesName, &seriesPosition,
+		&format, &purchasedAt, &purchasePrice, &pages, &notes, &summary, &seriesName, &seriesPosition,
 		&location, &condition, &acquisitionSource, &publishedYear, &publishedMonth,
 		&publishedDay, &createdAt, &updatedAt); err != nil {
 		return Book{}, err
@@ -278,6 +285,10 @@ func scanBook(scanner bookScanner) (Book, error) {
 
 	if purchasedAt.Valid {
 		book.PurchasedAt = &purchasedAt.String
+	}
+
+	if purchasePrice.Valid {
+		book.PurchasePrice = &purchasePrice.String
 	}
 
 	if pages.Valid {

--- a/internal/books/sqlite_repository_test.go
+++ b/internal/books/sqlite_repository_test.go
@@ -21,6 +21,7 @@ func TestSQLiteRepositoryCreatePersistsAllFields(t *testing.T) {
 	ed := "2nd"
 	format := books.FormatPaperback
 	purchased := "2025-06-15"
+	purchasePrice := "12.34 EUR"
 	pages := 400
 	notes := "Great book"
 	summary := "A practical Go guide"
@@ -41,6 +42,7 @@ func TestSQLiteRepositoryCreatePersistsAllFields(t *testing.T) {
 		Edition:           &ed,
 		Format:            &format,
 		PurchasedAt:       &purchased,
+		PurchasePrice:     &purchasePrice,
 		Pages:             &pages,
 		Notes:             &notes,
 		Summary:           &summary,
@@ -71,6 +73,7 @@ func TestSQLiteRepositoryCreatePersistsAllFields(t *testing.T) {
 		Edition:           &ed,
 		Format:            &f,
 		PurchasedAt:       &purchased,
+		PurchasePrice:     &purchasePrice,
 		Pages:             &pages,
 		Notes:             &notes,
 		Summary:           &summary,
@@ -146,6 +149,7 @@ func TestSQLiteRepositoryListReadsPersistedBooks(t *testing.T) {
 	ed := "2nd"
 	format := books.FormatPaperback
 	purchased := "2025-06-15"
+	purchasePrice := "12.34 EUR"
 	pages := 400
 	notes := "Great book"
 	summary := "A practical Go guide"
@@ -166,6 +170,7 @@ func TestSQLiteRepositoryListReadsPersistedBooks(t *testing.T) {
 		Edition:           &ed,
 		Format:            &format,
 		PurchasedAt:       &purchased,
+		PurchasePrice:     &purchasePrice,
 		Pages:             &pages,
 		Notes:             &notes,
 		Summary:           &summary,
@@ -222,6 +227,10 @@ func TestSQLiteRepositoryListReadsPersistedBooks(t *testing.T) {
 
 	if got.PurchasedAt == nil || *got.PurchasedAt != purchased {
 		t.Fatalf("expected PurchasedAt %q, got %#v", purchased, got.PurchasedAt)
+	}
+
+	if got.PurchasePrice == nil || *got.PurchasePrice != purchasePrice {
+		t.Fatalf("expected PurchasePrice %q, got %#v", purchasePrice, got.PurchasePrice)
 	}
 
 	if got.Pages == nil || *got.Pages != pages {

--- a/internal/cli/books.go
+++ b/internal/cli/books.go
@@ -141,6 +141,7 @@ func runBooksAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 	var edition optionalStringFlag
 	var format optionalStringFlag
 	var purchasedAt optionalStringFlag
+	var purchasePrice optionalStringFlag
 	var notes optionalStringFlag
 	var summary optionalStringFlag
 	var seriesName optionalStringFlag
@@ -159,6 +160,7 @@ func runBooksAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags.Var(&edition, "edition", "Book edition")
 	flags.Var(&format, "format", "Book format (hardback|paperback|epub)")
 	flags.Var(&purchasedAt, "purchased-at", "Date purchased (YYYY-MM-DD)")
+	flags.Var(&purchasePrice, "purchase-price", "Book purchase price (free-form text)")
 	flags.Var(&notes, "notes", "Personal notes")
 	flags.Var(&summary, "summary", "Book summary")
 	flags.Var(&seriesName, "series-name", "Book series name")
@@ -187,6 +189,7 @@ func runBooksAdd(args []string, stdout io.Writer, stderr io.Writer) int {
 		Publisher:         publisher.value,
 		Edition:           edition.value,
 		PurchasedAt:       purchasedAt.value,
+		PurchasePrice:     purchasePrice.value,
 		Pages:             pages.value,
 		Notes:             notes.value,
 		Summary:           summary.value,

--- a/internal/cli/books_test.go
+++ b/internal/cli/books_test.go
@@ -132,6 +132,7 @@ func TestBooksAddWithNewFields(t *testing.T) {
 	exitCode := cli.Run([]string{
 		"books", "add", "--title", "Full Book", "--language", "en", "--publisher", "O'Reilly",
 		"--edition", "2nd", "--format", "paperback", "--purchased-at", "2025-06-15",
+		"--purchase-price", "12.34 EUR",
 		"--pages", "400", "--notes", "Great read", "--summary", "A practical guide",
 		"--series-name", "Programming", "--series-position", "1.5", "--location", "Office shelf",
 		"--condition", "very_good", "--acquisition-source", "Bookshop", "--published-year", "2024",
@@ -170,6 +171,10 @@ func TestBooksAddWithNewFields(t *testing.T) {
 
 	if got.PurchasedAt == nil || *got.PurchasedAt != "2025-06-15" {
 		t.Fatalf("expected purchased_at '2025-06-15', got %#v", got.PurchasedAt)
+	}
+
+	if got.PurchasePrice == nil || *got.PurchasePrice != "12.34 EUR" {
+		t.Fatalf("expected purchase_price '12.34 EUR', got %#v", got.PurchasePrice)
 	}
 
 	if got.Pages == nil || *got.Pages != 400 {
@@ -232,7 +237,7 @@ func TestBooksAddSendsNullForOmittedOptionalFields(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
 	}
 	if posted.ISBN != nil || posted.Language != nil || posted.Publisher != nil || posted.Edition != nil ||
-		posted.Format != nil || posted.PurchasedAt != nil || posted.Pages != nil || posted.Notes != nil ||
+		posted.Format != nil || posted.PurchasedAt != nil || posted.PurchasePrice != nil || posted.Pages != nil || posted.Notes != nil ||
 		posted.Summary != nil || posted.SeriesName != nil || posted.SeriesPosition != nil ||
 		posted.Location != nil || posted.Condition != nil || posted.AcquisitionSource != nil ||
 		posted.PublishedYear != nil || posted.PublishedMonth != nil || posted.PublishedDay != nil {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -101,6 +101,7 @@ func TestInitialSchemaEnforcesBookValidation(t *testing.T) {
 		{title: "month without year", cols: "published_month", args: []any{1}},
 		{title: "invalid calendar day", cols: "published_year, published_month, published_day", args: []any{2023, 2, 29}},
 		{title: "invalid purchased date", cols: "purchased_at", args: []any{"2025-02-29"}},
+		{title: "blank purchase price", cols: "purchase_price", args: []any{" "}},
 	} {
 		placeholders := "?"
 		for range test.args[1:] {

--- a/internal/database/migrations/00001_initial_tables.sql
+++ b/internal/database/migrations/00001_initial_tables.sql
@@ -20,6 +20,7 @@ CREATE TABLE books (
             END
         )
     ),
+    purchase_price TEXT NULL CHECK (purchase_price IS NULL OR trim(purchase_price) <> ''),
     pages INTEGER NULL CHECK (pages IS NULL OR (typeof(pages) = 'integer' AND pages >= 1)),
     notes TEXT NULL,
     summary TEXT NULL,

--- a/internal/httpserver/books_test.go
+++ b/internal/httpserver/books_test.go
@@ -26,6 +26,7 @@ func TestBookAPICreate(t *testing.T) {
 		"edition":"1st",
 		"format":"paperback",
 		"purchased_at":"2025-06-15",
+		"purchase_price":"12.34 EUR",
 		"pages":412,
 		"notes":"Classic",
 		"summary":"A desert epic",
@@ -63,6 +64,9 @@ func TestBookAPICreate(t *testing.T) {
 	if created.ISBN == nil || *created.ISBN != "9780441172719" {
 		t.Fatalf("expected ISBN, got %#v", created.ISBN)
 	}
+	if created.PurchasePrice == nil || *created.PurchasePrice != "12.34 EUR" {
+		t.Fatalf("expected purchase_price, got %#v", created.PurchasePrice)
+	}
 
 	isbn := "9780441172719"
 	language := "en"
@@ -70,6 +74,7 @@ func TestBookAPICreate(t *testing.T) {
 	edition := "1st"
 	format := "paperback"
 	purchasedAt := "2025-06-15"
+	purchasePrice := "12.34 EUR"
 	pages := 412
 	notes := "Classic"
 	summary := "A desert epic"
@@ -91,6 +96,7 @@ func TestBookAPICreate(t *testing.T) {
 		Edition:           &edition,
 		Format:            &format,
 		PurchasedAt:       &purchasedAt,
+		PurchasePrice:     &purchasePrice,
 		Pages:             &pages,
 		Notes:             &notes,
 		Summary:           &summary,
@@ -190,6 +196,7 @@ func TestBookAPICreateNormalizesBlankExtendedTextToNull(t *testing.T) {
 	app := newTestApp(t)
 	body := bytes.NewBufferString(`{
 		"title":"Minimal",
+		"purchase_price":" ",
 		"summary":" ",
 		"series_name":" ",
 		"location":" ",
@@ -206,7 +213,7 @@ func TestBookAPICreateNormalizesBlankExtendedTextToNull(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
 		t.Fatal(err)
 	}
-	if created.Summary != nil || created.SeriesName != nil || created.SeriesPosition != nil ||
+	if created.PurchasePrice != nil || created.Summary != nil || created.SeriesName != nil || created.SeriesPosition != nil ||
 		created.Location != nil || created.Condition != nil || created.AcquisitionSource != nil {
 		t.Fatalf("expected nullable extended metadata, got %#v", created)
 	}
@@ -244,12 +251,12 @@ func TestBookAPIList(t *testing.T) {
 	id := int64(100)
 	_, err := app.db.ExecContext(context.Background(), `
 		INSERT INTO books (id, title, isbn, language, publisher, edition, format,
-		                   purchased_at, pages, notes, summary, series_name,
+		                   purchased_at, purchase_price, pages, notes, summary, series_name,
 		                   series_position, location, condition, acquisition_source,
 		                   published_year, published_month, published_day, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id, "Dune", "9780441172719", "en", "Chilton", "1st", "paperback", "2025-06-15",
-		412, "Classic", "A desert epic", "Dune", 1.5, "Living room", "very_good", "Bookshop",
+		"12.34 EUR", 412, "Classic", "A desert epic", "Dune", 1.5, "Living room", "very_good", "Bookshop",
 		1965, 8, 1, now, now)
 	if err != nil {
 		t.Fatal(err)
@@ -296,6 +303,9 @@ func TestBookAPIList(t *testing.T) {
 	}
 	if got.PurchasedAt == nil || *got.PurchasedAt != "2025-06-15" {
 		t.Fatalf("expected purchased_at '2025-06-15', got %#v", got.PurchasedAt)
+	}
+	if got.PurchasePrice == nil || *got.PurchasePrice != "12.34 EUR" {
+		t.Fatalf("expected purchase_price '12.34 EUR', got %#v", got.PurchasePrice)
 	}
 	if got.Pages == nil || *got.Pages != 412 {
 		t.Fatalf("expected pages 412, got %#v", got.Pages)

--- a/internal/testsupport/books.go
+++ b/internal/testsupport/books.go
@@ -48,6 +48,7 @@ type BookRowAssertion struct {
 	Edition           *string
 	Format            *string
 	PurchasedAt       *string
+	PurchasePrice     *string
 	Pages             *int
 	Notes             *string
 	Summary           *string
@@ -104,6 +105,7 @@ func AssertBookRowFields(t testing.TB, db *sql.DB, id int64, want BookRowAsserti
 	var edition sql.NullString
 	var format sql.NullString
 	var purchasedAt sql.NullString
+	var purchasePrice sql.NullString
 	var notes sql.NullString
 	var summary sql.NullString
 	var seriesName sql.NullString
@@ -119,14 +121,14 @@ func AssertBookRowFields(t testing.TB, db *sql.DB, id int64, want BookRowAsserti
 	var updatedAt string
 
 	err := db.QueryRowContext(context.Background(), `
-		SELECT title, isbn, language, publisher, edition, format, purchased_at,
+		SELECT title, isbn, language, publisher, edition, format, purchased_at, purchase_price,
 		    pages, notes, summary, series_name, series_position, location,
 		    condition, acquisition_source, published_year, published_month, published_day,
 		    created_at, updated_at
 		FROM books
 		WHERE id = ?
 	`, id).Scan(&title, &isbn, &language, &publisher, &edition,
-		&format, &purchasedAt, &pages, &notes, &summary, &seriesName, &seriesPosition,
+		&format, &purchasedAt, &purchasePrice, &pages, &notes, &summary, &seriesName, &seriesPosition,
 		&location, &condition, &acquisitionSource, &publishedYear, &publishedMonth,
 		&publishedDay, &createdAt, &updatedAt)
 	if err != nil {
@@ -143,6 +145,7 @@ func AssertBookRowFields(t testing.TB, db *sql.DB, id int64, want BookRowAsserti
 	assertNullString(t, "edition", edition, want.Edition)
 	assertNullString(t, "format", format, want.Format)
 	assertNullString(t, "purchased_at", purchasedAt, want.PurchasedAt)
+	assertNullString(t, "purchase_price", purchasePrice, want.PurchasePrice)
 	assertNullInt(t, "pages", pages, want.Pages)
 	assertNullString(t, "notes", notes, want.Notes)
 	assertNullString(t, "summary", summary, want.Summary)


### PR DESCRIPTION
Allow an optional purchase price to be recorded as display-oriented text without imposing currency or numeric semantics.

- Expose purchase_price through SQLite, the book JSON API, and repository reads and writes
- Add --purchase-price to books add and normalize blank values to NULL
- Cover schema, service, repository, HTTP, and CLI behavior